### PR TITLE
feat(ios): implement CallKit integration with shared call abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,561 +1,392 @@
 # Ringlr
 
-Ringlr is a cross-platform application designed to handle and integrate phone calls and audio configurations. It leverages platform-specific APIs such as Android's Telecom framework and iOS's CallKit to provide a seamless calling experience.
+Ringlr is a Kotlin Multiplatform Mobile (KMM) library for handling phone calls and audio configuration across Android and iOS. It provides a single unified API on top of Android's Telecom framework and iOS's CallKit.
 
 ![ringlr_](https://github.com/user-attachments/assets/65f924e5-8f70-4bd1-87a5-a99eac86eae7)
 
 ## Contents
 - [Features](#features)
-- [Upcoming Changes](#upcoming-changes-and-work-left)
+- [Upcoming Changes](#upcoming-changes)
 - [Contribution Guidelines](https://github.com/Rohit-554/Ringlr/blob/master/Contributing.md)
 - [Permissions](#permissions)
 - [Implementation Guide](#implementation-guide)
-  - [Local Library Integration](#local-library-integration)
+  - [Local Library Integration](#1-local-library-integration)
   - [Initialize the Library](#2-initialize-the-library)
   - [Permission Handling](#3-permission-handling)
   - [Making Calls](#4-making-calls)
   - [Complete App.kt Example](#complete-appkt-example)
 - [CallManager API Reference](#callmanager-api-reference)
-  - [Class Declaration](#class-declaration)
-  - [Constructor Parameters](#constructor-parameters)
-  - [Call Management Functions](#call-management-functions)
-  - [Call State Control](#call-state-control)
-  - [Call Information](#call-information)
-  - [Audio Route Management](#audio-route-management)
-  - [Callback Management](#callback-management)
-  - [Example Usage](#example-usage)
-- [Getting Started](#getting-started)
-  - [Project Structure](#project-structure)
-  - [Installation](#installation)
+- [Project Structure](#project-structure)
 - [Important Notes](#important-notes)
 - [Troubleshooting](#troubleshooting)
 - [Building the Project](#building-the-project)
-  
+
+---
 
 ## Features
 
-- Answer and make phone calls
-- Grant permissions 
-- Manage call states (mute, hold, end)
-- Configure audio settings
-- Bluetooth support
+- Make and manage outgoing phone calls
+- Answer incoming calls (via system UI)
+- Mute, hold, and end active calls
+- Route audio to speaker, earpiece, Bluetooth, or wired headset
+- Request and check call and microphone permissions
+- Real-time call state callbacks
+- Android Telecom framework integration
+- iOS CallKit integration
 
-# Upcoming Changes and Work Left
+---
 
-## In Progress
-- ✨ Writing actual classes for Ios
+## Upcoming Changes
 
-## Coming Soon
-- ✨ VoIP support
-- ✨ Custom in-app calling
+- ✨ VoIP / SIP support
+- ✨ Custom in-app calling UI
 - ✨ Publishing on Maven Central
+
+---
 
 ## Permissions
 
-The application can handle these permissions right now:
-
 ### Android
 
-- `android.permission.ANSWER_PHONE_CALLS`
-- `android.permission.CALL_PHONE`
-- `android.permission.READ_PHONE_STATE`
-- `android.permission.MANAGE_OWN_CALLS`
-- `android.permission.READ_PHONE_NUMBERS`
-- `android.permission.MODIFY_AUDIO_SETTINGS`
-- `android.permission.RECORD_AUDIO`
-- `android.permission.BLUETOOTH`
-- `android.permission.BLUETOOTH_CONNECT`
+Declare these in your `AndroidManifest.xml`:
 
-# CallManager API Reference
+| Permission | Purpose |
+|---|---|
+| `ANSWER_PHONE_CALLS` | Answer incoming calls programmatically |
+| `CALL_PHONE` | Place outgoing calls |
+| `READ_PHONE_STATE` | Read active call state |
+| `MANAGE_OWN_CALLS` | Register a custom phone account |
+| `READ_PHONE_NUMBERS` | Read the device's phone number |
+| `MODIFY_AUDIO_SETTINGS` | Switch audio routes |
+| `RECORD_AUDIO` | Microphone access during calls |
+| `BLUETOOTH` / `BLUETOOTH_CONNECT` | Bluetooth headset support |
 
-The `CallManager` class is the core component for handling call-related operations in Ringlr. It implements the `CallManagerInterface` and provides comprehensive call management functionality.
+### iOS
 
-## Class Declaration
+Add these keys to your `Info.plist`:
+
+| Key | Purpose |
+|---|---|
+| `NSMicrophoneUsageDescription` | Microphone access during calls |
+| `NSBluetoothAlwaysUsageDescription` | Bluetooth headset support |
+
+iOS call access (CallKit) is managed by the system — no runtime `CALL_PHONE` equivalent is required.
+
+---
+
+## CallManager API Reference
+
+`CallManager` is the single entry point for all call operations.
 
 ```kotlin
 expect class CallManager(configuration: PlatformConfiguration) : CallManagerInterface
 ```
 
-## Constructor Parameters
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `configuration` | `PlatformConfiguration` | Platform-specific configuration for call handling |
-
-## Call Management Functions
-
-### Outgoing Call Control
+### Outgoing Calls
 
 ```kotlin
 suspend fun startOutgoingCall(
     number: String,
     displayName: String,
-    scheme: String
+    scheme: String = "tel"   // "tel" for PSTN, "sip" for VoIP
 ): CallResult<Call>
-```
-Initiates an outgoing call.
-- `number`: Phone number to call
-- `displayName`: Name to display for the call
-- `scheme`: URI scheme for the call (e.g., "tel", "sip")
-- Returns: Result containing the Call object if successful
 
-```kotlin
 suspend fun endCall(callId: String): CallResult<Unit>
 ```
-Ends an active call.
-- `callId`: Identifier of the call to end
 
 ### Call State Control
 
 ```kotlin
 suspend fun muteCall(callId: String, muted: Boolean): CallResult<Unit>
-```
-Controls call muting.
-- `callId`: Identifier of the call
-- `muted`: True to mute, false to unmute
-
-```kotlin
 suspend fun holdCall(callId: String, onHold: Boolean): CallResult<Unit>
 ```
-Controls call hold state.
-- `callId`: Identifier of the call
-- `onHold`: True to hold, false to resume
 
-## Call Information
+### Call Information
 
 ```kotlin
 suspend fun getCallState(callId: String): CallResult<CallState>
-```
-Retrieves the current state of a call.
-- `callId`: Identifier of the call
-- Returns: Current CallState
-
-```kotlin
 suspend fun getActiveCalls(): CallResult<List<Call>>
 ```
-Gets a list of all active calls.
-- Returns: List of active Call objects
 
-## Audio Route Management
+### Audio Route Management
 
 ```kotlin
 suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit>
-```
-Sets the audio output route.
-- `route`: Desired AudioRoute (e.g., SPEAKER, EARPIECE, BLUETOOTH)
-
-```kotlin
 suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
 ```
-Gets the current audio route.
-- Returns: Current AudioRoute
 
-## Callback Management
+`AudioRoute` values: `SPEAKER`, `EARPIECE`, `BLUETOOTH`, `WIRED_HEADSET`
+
+### Callbacks
 
 ```kotlin
 fun registerCallStateCallback(callback: CallStateCallback)
-```
-Registers a callback for call state changes.
-- `callback`: CallStateCallback implementation to receive updates
-
-```kotlin
 fun unregisterCallStateCallback(callback: CallStateCallback)
 ```
-Unregisters a previously registered callback.
-- `callback`: CallStateCallback to unregister
 
-## Example Usage
+`CallStateCallback` events: `onCallStateChanged`, `onCallAdded`, `onCallRemoved`
+
+### CallResult
+
+Every operation returns `CallResult<T>` — either `Success(data)` or `Error(callError)`. No exceptions leak through the API boundary.
 
 ```kotlin
-val callManager = CallManager(platformConfiguration)
-
-// Start an outgoing call
-val callResult = callManager.startOutgoingCall(
-    number = "+1234567890",
-    displayName = "John Doe",
-    scheme = "tel"
-)
-
-// Handle call state changes
-val callback = object : CallStateCallback {
-    override fun onCallStateChanged(call: Call, state: CallState) {
-        // Handle state change
-    }
+when (val result = callManager.startOutgoingCall("+1234567890", "John Doe")) {
+    is CallResult.Success -> println("Call started: ${result.data.id}")
+    is CallResult.Error   -> println("Failed: ${result.error}")
 }
-callManager.registerCallStateCallback(callback)
-
-// End call
-callResult.onSuccess { call ->
-    callManager.endCall(call.id)
-}
-
-// Clean up
-callManager.unregisterCallStateCallback(callback)
 ```
-## Getting Started
 
-### Project Structure 
-```
-ringlr/
-├── androidApp/           # Android specific code
-│   ├── src/
-│   │   ├── main/
-│   │   │   ├── java/    # Android implementation
-│   │   │   └── res/     # Android resources
-│   │   └── test/        # Android tests
-├── shared/              # Shared KMM code
-│   ├── src/
-│   │   ├── commonMain/  # Common code
-│   │   ├── androidMain/ # Android-specific implementations
-│   │   └── iosMain/     # iOS-specific implementations
-└── iosApp/              # iOS specific code (planned)
+---
+
+## Project Structure
 
 ```
-### Installation
+shared/
+└── src/
+    ├── commonMain/          # Shared interfaces, models, expect declarations
+    │   └── call/
+    │       ├── CallHandler.kt          # expect PlatformConfiguration + CallManager
+    │       ├── CallManagerInterface.kt
+    │       ├── Call.kt
+    │       ├── CallState.kt
+    │       ├── CallResult.kt
+    │       ├── CallError.kt
+    │       ├── AudioRoute.kt
+    │       └── CallStateCallback.kt
+    ├── androidMain/         # Android Telecom implementation
+    │   └── call/
+    │       ├── CallHandler.android.kt
+    │       ├── TelecomConnectionService.kt
+    │       └── PhoneAccountRegistrar.kt
+    └── iosMain/             # iOS CallKit implementation
+        └── call/
+            ├── CallHandler.ios.kt
+            └── callkit/
+                ├── ActiveCallRegistry.kt      # Tracks Call ↔ NSUUID
+                ├── SystemCallBridge.kt        # CXProviderDelegate
+                ├── CallActionDispatcher.kt    # Submits CXTransactions
+                └── CallAudioRouter.kt         # AVAudioSession routing
+```
+
+---
+
+## Implementation Guide
+
+### 1. Local Library Integration
+
+Ringlr is available as a local Gradle module.
 
 1. Clone the repository:
-    ```sh
-    git clone https://github.com/yourusername/ringlr.git
-    ```
-
-# Implementation Guide
-
-### Local Library Integration
-
-Ringlr is currently available as a local module. Follow these steps to integrate it into your project:
-
-1. Clone the Ringlr repository:
 ```bash
 git clone https://github.com/Rohit-554/Ringlr.git
 ```
 
-2. Import the `shared` module:
-   - Copy the `shared` directory from the cloned repository to your project's root directory
+2. Copy the `shared` directory into your project root.
 
-3. Add the module to your project's settings.gradle.kts:
+3. Add to `settings.gradle.kts`:
 ```kotlin
-// settings.gradle.kts
 include(":shared")
 ```
 
-4. Add the dependency in your app's build.gradle.kts:
+4. Add the dependency in your app's `build.gradle.kts`:
 ```kotlin
-// app/build.gradle.kts
 dependencies {
     implementation(project(":shared"))
 }
 ```
 
-5. Sync your project with Gradle files
+5. Sync Gradle.
 
-Note: Make sure the `shared` module's Gradle configuration is compatible with your project's Gradle version and configuration.
+---
 
 ### 2. Initialize the Library
 
-Create an Application class in your androidMain source set:
+#### Android
+
+Create an `Application` class and call `PlatformConfiguration.init`:
 
 ```kotlin
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        // Initialize the Platform Configuration
         PlatformConfiguration.init(this)
     }
 }
 ```
 
-Don't forget to declare your Application class in the AndroidManifest.xml along with the service class:
+Register it in `AndroidManifest.xml` along with the `ConnectionService`:
 
 ```xml
-<application
-    android:name=".MyApplication"
-    ...>
- <service
-            android:name=".ringlr.callHandler.CallConnectionService"
-            android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.telecom.ConnectionService" />
-            </intent-filter>
-        </service>
+<application android:name=".MyApplication">
+    <service
+        android:name=".ringlr.callHandler.CallConnectionService"
+        android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="android.telecom.ConnectionService" />
+        </intent-filter>
+    </service>
 </application>
-``` 
+```
 
+#### iOS
 
+No `Application` subclass is needed. Create and initialise `PlatformConfiguration` directly in your Compose entry point:
+
+```kotlin
+val platformConfig = PlatformConfiguration.create()
+platformConfig.initializeCallConfiguration()
+```
+
+Make sure `NSMicrophoneUsageDescription` and `NSBluetoothAlwaysUsageDescription` are set in `Info.plist`.
+
+---
 
 ### 3. Permission Handling
-
-Ringlr requires specific permissions to handle calls. Here's how to implement the permission flow in your Compose UI:
-
-#### Basic Permission Setup
-
-in AndroidManifest.xml androidMain[main] (your project manifest) configure what permissions you want
-```xml
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-    <!-- Essential permissions for call handling -->
-    <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
-    <uses-permission android:name="android.permission.CALL_PHONE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
-
-    <!-- Permissions for audio handling -->
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-
-    <!-- Bluetooth permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-
-    <!-- Feature declarations -->
-    <uses-feature android:name="android.hardware.telephony" android:required="true" />
-    <uses-feature android:name="android.hardware.microphone" android:required="true" />
- ...
-```
 
 ```kotlin
 @Composable
 fun App() {
-    // Initialize permission controller
-    val factory: PermissionsControllerFactory = rememberPermissionsControllerFactory()
-    val controller: PermissionsController = remember(factory) { 
-        factory.createPermissionsController() 
-    }
-    
-    // Bind the controller
+    val factory = rememberPermissionsControllerFactory()
+    val controller = remember(factory) { factory.createPermissionsController() }
     BindEffect(controller)
-    
-    // Your UI content
+
+    // ... your UI
 }
 ```
 
-#### Complete Permission Flow Example
-
-Here's a complete example of handling call permissions and making calls:
+Requesting a permission:
 
 ```kotlin
-@Composable
-fun CallScreen(
-    phoneNumber: String,
-    platformConfig: PlatformConfig
-) {
-    val scope = rememberCoroutineScope()
-    
-    Button(
-        onClick = {
-            scope.launch {
-                try {
-                    val initialState = controller.getPermissionState(Permission.CALL_PHONE)
-
-                    when (initialState) {
-                        PermissionState.Granted -> {
-                            // Permission already granted, make the call
-                            CallManager(platformConfig).startOutgoingCall(
-                                phoneNumber,
-                                "Call from KMM"
-                            )
-                        }
-                        PermissionState.DeniedAlways -> {
-                            return@launch
-                        }
-                        else -> {
-                            // Request permission
-                            handlePermissionRequest(
-                                controller,
-                                phoneNumber,
-                                platformConfig
-                            )
-                        }
-                    }
-                } catch (e: Exception) {
-                    handlePermissionError(e)
-                }
+scope.launch {
+    when (controller.getPermissionState(Permission.CALL_PHONE)) {
+        PermissionState.Granted -> placeCall()
+        PermissionState.DeniedAlways -> showOpenSettingsPrompt()
+        else -> {
+            try {
+                controller.providePermission(Permission.CALL_PHONE)
+                placeCall()
+            } catch (e: DeniedAlwaysException) {
+                showOpenSettingsPrompt()
+            } catch (e: DeniedException) {
+                showPermissionRationale()
             }
         }
-    ) {
-        Text("Make Call")
-    }
-}
-
-private suspend fun handlePermissionRequest(
-    controller: PermissionsController,
-    phoneNumber: String,
-    platformConfig: PlatformConfig
-) {
-    try {
-        controller.providePermission(Permission.CALL_PHONE)
-        
-        when (controller.getPermissionState(Permission.CALL_PHONE)) {
-            PermissionState.Granted -> {
-                CallManager(platformConfig).startOutgoingCall(
-                    phoneNumber,
-                    "Call from KMM"
-                )
-            }
-            PermissionState.DeniedAlways -> {
-                return
-            }
-            else -> {
-                return
-            }
-        }
-    } catch (e: Exception) {
-        handlePermissionError(e)
-    }
-}
-
-private fun handlePermissionError(error: Exception) {
-    // Handle errors according to your app's needs
-    when (error) {
-        is DeniedAlwaysException -> { /* Handle permanent denial */ }
-        is DeniedException -> { /* Handle temporary denial */ }
-        else -> { /* Handle other errors */ }
     }
 }
 ```
+
+Available permissions: `Permission.CALL_PHONE`, `Permission.MICROPHONE`, `Permission.BLUETOOTH`, `Permission.BLUETOOTH_CONNECT`, `Permission.RECORD_AUDIO`, and more.
+
+---
 
 ### 4. Making Calls
 
-Once permissions are granted, you can use the `CallManager` to initiate calls:
-
 ```kotlin
-CallManager(platformConfig).startOutgoingCall(
-    phoneNumber = phoneNumber,    // The phone number to call
-    displayName = "Call from KMM" // Display name shown on the call screen
+val platformConfig = PlatformConfiguration.create()
+platformConfig.initializeCallConfiguration()
+val callManager = CallManager(platformConfig)
+
+val result = callManager.startOutgoingCall(
+    number = "+1234567890",
+    displayName = "John Doe"
 )
+
+when (result) {
+    is CallResult.Success -> {
+        val call = result.data
+        // register a callback, mute, hold, end, etc.
+    }
+    is CallResult.Error -> {
+        // handle result.error
+    }
+}
 ```
 
-This will launch the default system dialer app to make the call.
+---
 
 ### Complete App.kt Example
-
-Here's a complete example of how your App.kt might look:
 
 ```kotlin
 @Composable
 @Preview
 fun App() {
-    val isToastTapped = remember { mutableStateOf(false) }
+    val platformConfig = remember {
+        PlatformConfiguration.create().also { it.initializeCallConfiguration() }
+    }
+    val callManager = remember { CallManager(platformConfig) }
+    val scope = rememberCoroutineScope()
+
+    val factory = rememberPermissionsControllerFactory()
+    val controller = remember(factory) { factory.createPermissionsController() }
+    BindEffect(controller)
+
     MaterialTheme {
-            Scaffold(
-                Modifier.fillMaxSize()
+        Scaffold(Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
             ) {
-                val platformConfig = PlatformConfiguration.create()
-                platformConfig.initializeCallConfiguration()
-                val scope = rememberCoroutineScope()
+                var phoneNumber by remember { mutableStateOf("") }
 
-                val factory: PermissionsControllerFactory = rememberPermissionsControllerFactory()
-                val controller: PermissionsController = remember(factory) { factory.createPermissionsController() }
-                BindEffect(controller)
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    var phoneNumber by remember { mutableStateOf("") }
+                TextField(
+                    value = phoneNumber,
+                    onValueChange = { phoneNumber = it },
+                    label = { Text("Enter phone number") },
+                    modifier = Modifier.fillMaxWidth().padding(16.dp)
+                )
 
-                    TextField(
-                        value = phoneNumber,
-                        onValueChange = { phoneNumber = it },
-                        label = { Text("Enter phone number") },
-                        modifier = Modifier.fillMaxWidth().padding(16.dp)
-                    )
-
-                    Button(
-                        onClick = {
-                            scope.launch {
-                                try {
-                                    val initialState = controller.getPermissionState(Permission.CALL_PHONE)
-
-                                    when (initialState) {
-                                        PermissionState.Granted -> {
-                                            // Permission already granted, proceed with call
-                                            CallManager(platformConfig).startOutgoingCall(
-                                                phoneNumber,
-                                                "Call from KMM"
-                                            )
-                                        }
-                                        PermissionState.DeniedAlways -> {
-                                           // print denied always
-                                            return@launch
-                                        }
-                                        else -> {
-                                            // Request permission
-                                            try {
-                                                controller.providePermission(Permission.CALL_PHONE)
-
-                                                // Check result after permission request
-                                                when (controller.getPermissionState(Permission.CALL_PHONE)) {
-                                                    PermissionState.Granted -> {
-                                                        CallManager(platformConfig).startOutgoingCall(
-                                                            phoneNumber,
-                                                            "Call from KMM"
-                                                        )
-                                                    }
-                                                    PermissionState.DeniedAlways -> {
-                                                        //print permission denied
-                                                        return@launch
-                                                    }
-                                                    else -> {
-                                                        // print permission required to make calls 
-                                                        return@launch
-                                                    }
-                                                }
-                                            } catch (e: DeniedAlwaysException) {
-                                                toastManager.showShortToast("Permission permanently denied")
-                                                return@launch
-                                            } catch (e: DeniedException) {
-                                                toastManager.showShortToast("Permission denied")
-                                                return@launch
-                                            }
-                                        }
-                                    }
-                                } catch (e: DeniedAlwaysException) {
-                                   //print exception
-                                } catch (e: DeniedException) {
-                                    toastManager.showShortToast("Permission denied")
-                                } catch (e: Exception) {
-                                   //print exception
-                                }
+                Button(
+                    onClick = {
+                        scope.launch {
+                            try {
+                                controller.providePermission(Permission.CALL_PHONE)
+                                callManager.startOutgoingCall(phoneNumber, "Call from KMM")
+                            } catch (e: DeniedAlwaysException) {
+                                controller.openAppSettings()
+                            } catch (e: DeniedException) {
+                                // show rationale
                             }
-                        },
-                        modifier = Modifier.padding(16.dp)
-                    ) {
-                        Text("Call")
-                    }
+                        }
+                    },
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    Text("Call")
                 }
             }
+        }
     }
 }
-
 ```
+
+---
 
 ## Important Notes
 
-- The `CallManager` requires valid platform configuration to work properly
-- Always handle permission cases appropriately to ensure good user experience
-- The library will use the system's default dialer app for making calls
-- Make sure to handle all potential exceptions when requesting permissions
-- Test the implementation thoroughly on different Android versions
+- Always call `initializeCallConfiguration()` before constructing `CallManager`
+- Call `cleanupCallConfiguration()` when the calling session ends (e.g., `onDestroy`)
+- On Android, register `TelecomConnectionService` in your manifest — calls will silently fail otherwise
+- On iOS, the `CXProvider` is a singleton per app; `PlatformConfiguration` owns it and must not be recreated per call
+- Always unregister callbacks to avoid memory leaks
+
+---
 
 ## Troubleshooting
 
-Common issues and their solutions:
+| Problem | Solution |
+|---|---|
+| Call never starts on Android | Check `TelecomConnectionService` is declared in the manifest with the correct permission |
+| Permission permanently denied | Call `controller.openAppSettings()` to redirect the user |
+| Audio routes back to earpiece after Bluetooth connects | Re-call `setAudioRoute(AudioRoute.BLUETOOTH)` after `onCallStateChanged` fires `ACTIVE` |
+| iOS call does not show system call UI | Ensure `PlatformConfiguration.initializeCallConfiguration()` was called before placing the call |
+| `CallResult.Error(CallNotFound)` | The `callId` was not found — use the `id` from the `Call` returned by `startOutgoingCall` |
 
-1. Permission Denied Always:
-   - Guide users to app settings to enable permissions manually
-   - Consider implementing your own user feedback mechanism
+---
 
-2. Call Failed to Initialize:
-   - Verify platform configuration is properly initialized
-   - Check if all required permissions are granted
+## Building the Project
 
-3. Permission Flow Issues:
-   - Ensure `BindEffect` is called with the controller
-   - Verify the permission state handling in all cases
-
-### Building the Project
-
-To build the project, use the following Gradle command:
 ```sh
 ./gradlew build
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
+    alias(libs.plugins.androidApplication).apply(false)
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.androidKmpLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
+    alias(libs.plugins.compose.compiler).apply(false)
     alias(libs.plugins.kotlinCocoapods).apply(false)
 }

--- a/demoApp/build.gradle.kts
+++ b/demoApp/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "io.jadu.ringlr.demo"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "io.jadu.ringlr.demo"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
+}

--- a/demoApp/src/main/AndroidManifest.xml
+++ b/demoApp/src/main/AndroidManifest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <uses-feature android:name="android.hardware.telephony" android:required="true" />
+    <uses-feature android:name="android.hardware.microphone" android:required="true" />
+
+    <application
+        android:name=".DemoApplication"
+        android:label="Ringlr Demo"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar"
+        tools:replace="android:name">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name="io.jadu.ringlr.call.TelecomConnectionService"
+            android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.telecom.ConnectionService" />
+            </intent-filter>
+        </service>
+
+    </application>
+
+</manifest>

--- a/demoApp/src/main/kotlin/io/jadu/ringlr/demo/DemoApplication.kt
+++ b/demoApp/src/main/kotlin/io/jadu/ringlr/demo/DemoApplication.kt
@@ -1,0 +1,16 @@
+package io.jadu.ringlr.demo
+
+import android.app.Application
+import io.jadu.ringlr.call.PlatformConfiguration
+
+/**
+ * Initialises the Ringlr Android calling stack once, at application startup.
+ * PlatformConfiguration.init stores the application Context so that
+ * TelecomManager can be resolved without passing Context everywhere.
+ */
+class DemoApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        PlatformConfiguration.init(this)
+    }
+}

--- a/demoApp/src/main/kotlin/io/jadu/ringlr/demo/MainActivity.kt
+++ b/demoApp/src/main/kotlin/io/jadu/ringlr/demo/MainActivity.kt
@@ -1,0 +1,27 @@
+package io.jadu.ringlr.demo
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import io.jadu.ringlr.App
+import io.jadu.ringlr.call.PlatformConfiguration
+
+/**
+ * Single-activity host for the Ringlr demo.
+ * Creates PlatformConfiguration (Context already stored via DemoApplication),
+ * then delegates all UI to the shared App composable.
+ */
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val configuration = PlatformConfiguration.create()
+
+        setContent {
+            App(configuration = configuration)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ compose-material3 = "1.3.1"
 androidx-activityCompose = "1.10.1"
 kotlinxCoroutinesCore = "1.10.1"
 composeMultiplatformRuntime = "1.8.0"
+jetbrainsCompose = "1.8.0"
 
 [libraries]
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koinAndroid" }
@@ -19,6 +20,9 @@ compose-foundation = { module = "androidx.compose.foundation:foundation", versio
 compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 compose-multiplatform-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatformRuntime" }
+compose-multiplatform-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatformRuntime" }
+compose-multiplatform-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatformRuntime" }
+compose-multiplatform-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMultiplatformRuntime" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -28,3 +32,4 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "jetbrainsCompose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Ringlr"
 include(":shared")
+include(":demoApp")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKmpLibrary)
-    id("org.jetbrains.kotlin.plugin.compose") version libs.versions.kotlin
+    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {
@@ -28,6 +28,9 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(libs.compose.multiplatform.runtime)
+            implementation(libs.compose.multiplatform.ui)
+            implementation(libs.compose.multiplatform.foundation)
+            implementation(libs.compose.multiplatform.material3)
             implementation(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {

--- a/shared/src/androidMain/kotlin/io/jadu/ringlr/call/CallHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/jadu/ringlr/call/CallHandler.android.kt
@@ -212,6 +212,7 @@ actual class CallManager actual constructor(
         }
     }
 
+    @Suppress("NewApi")
     private fun setAudioRouteModern(audioManager: AudioManager, route: AudioRoute): CallResult<Unit> {
         val devices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
         val preferredDevice = when (route) {
@@ -256,6 +257,7 @@ actual class CallManager actual constructor(
         }
     }
 
+    @Suppress("NewApi")
     private fun resolveAudioRouteModern(audioManager: AudioManager): AudioRoute {
         return when (audioManager.communicationDevice?.type) {
             AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AudioRoute.SPEAKER

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/App.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/App.kt
@@ -1,0 +1,35 @@
+package io.jadu.ringlr
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import io.jadu.ringlr.call.CallManager
+import io.jadu.ringlr.call.PlatformConfiguration
+import io.jadu.ringlr.permission.factory.BindEffect
+import io.jadu.ringlr.permission.factory.rememberPermissionsControllerFactory
+
+/**
+ * Root composable shared by Android (MainActivity) and iOS (MainViewController).
+ *
+ * Initialises the calling stack and permission controller exactly once,
+ * then hands them to CallScreen.
+ */
+@Composable
+fun App(configuration: PlatformConfiguration) {
+    val callManager = remember(configuration) {
+        configuration.initializeCallConfiguration()
+        CallManager(configuration)
+    }
+
+    val factory = rememberPermissionsControllerFactory()
+    val permissionsController = remember(factory) { factory.createPermissionsController() }
+    BindEffect(permissionsController)
+
+    MaterialTheme(colorScheme = darkColorScheme()) {
+        CallScreen(
+            callManager = callManager,
+            permissionsController = permissionsController
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/CallScreen.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/CallScreen.kt
@@ -1,0 +1,320 @@
+package io.jadu.ringlr
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.jadu.ringlr.call.AudioRoute
+import io.jadu.ringlr.call.Call
+import io.jadu.ringlr.call.CallManager
+import io.jadu.ringlr.call.CallResult
+import io.jadu.ringlr.call.CallState
+import io.jadu.ringlr.call.CallStateCallback
+import io.jadu.ringlr.permission.DeniedAlwaysException
+import io.jadu.ringlr.permission.DeniedException
+import io.jadu.ringlr.permission.Permission
+import io.jadu.ringlr.permission.PermissionState
+import io.jadu.ringlr.permission.PermissionsController
+import io.jadu.ringlr.permission.delegate.CALL_PHONE
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * The single screen of the Ringlr demo.
+ *
+ * Shows a [Dialer] when no call is active, and switches to [ActiveCallPanel]
+ * once a call is in progress. Call state changes arrive via [ObserveCallState].
+ */
+@Composable
+fun CallScreen(callManager: CallManager, permissionsController: PermissionsController) {
+    val scope = rememberCoroutineScope()
+    var activeCall by remember { mutableStateOf<Call?>(null) }
+    var errorMessage by remember { mutableStateOf("") }
+
+    ObserveCallState(
+        callManager = callManager,
+        onCallUpdated = { call -> activeCall = call },
+        onCallEnded = { activeCall = null }
+    )
+
+    Scaffold { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (activeCall == null) {
+                Dialer(
+                    errorMessage = errorMessage,
+                    onCallRequested = { number ->
+                        errorMessage = ""
+                        scope.placeCallWithPermissionCheck(
+                            number = number,
+                            callManager = callManager,
+                            permissionsController = permissionsController,
+                            onError = { errorMessage = it }
+                        )
+                    }
+                )
+            } else {
+                ActiveCallPanel(
+                    call = activeCall!!,
+                    callManager = callManager,
+                    onCallEnded = { activeCall = null }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Dialer(errorMessage: String, onCallRequested: (number: String) -> Unit) {
+    var phoneNumber by remember { mutableStateOf("") }
+
+    Text("Ringlr Demo", style = MaterialTheme.typography.headlineMedium)
+
+    Spacer(Modifier.height(32.dp))
+
+    OutlinedTextField(
+        value = phoneNumber,
+        onValueChange = { phoneNumber = it },
+        label = { Text("Phone number") },
+        placeholder = { Text("+1 555 000 0000") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth()
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    Button(
+        onClick = { onCallRequested(phoneNumber) },
+        enabled = phoneNumber.isNotBlank(),
+        modifier = Modifier.fillMaxWidth().height(52.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50))
+    ) {
+        Text("Call", style = MaterialTheme.typography.titleMedium)
+    }
+
+    if (errorMessage.isNotBlank()) {
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = errorMessage,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+@Composable
+private fun ActiveCallPanel(call: Call, callManager: CallManager, onCallEnded: () -> Unit) {
+    val scope = rememberCoroutineScope()
+    var isMuted by remember { mutableStateOf(false) }
+    var isOnHold by remember { mutableStateOf(false) }
+    var audioRoute by remember { mutableStateOf(AudioRoute.EARPIECE) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(call.displayName, style = MaterialTheme.typography.titleLarge)
+            Text(
+                text = call.number,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            CallStateBadge(call.state)
+
+            Spacer(Modifier.height(24.dp))
+
+            CallControlRow(
+                isMuted = isMuted,
+                isOnHold = isOnHold,
+                onMuteToggled = {
+                    scope.launch {
+                        val next = !isMuted
+                        if (callManager.muteCall(call.id, next) is CallResult.Success) isMuted = next
+                    }
+                },
+                onHoldToggled = {
+                    scope.launch {
+                        val next = !isOnHold
+                        if (callManager.holdCall(call.id, next) is CallResult.Success) isOnHold = next
+                    }
+                }
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            AudioRouteSelector(
+                selected = audioRoute,
+                onRouteSelected = { route ->
+                    scope.launch {
+                        if (callManager.setAudioRoute(route) is CallResult.Success) audioRoute = route
+                    }
+                }
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        callManager.endCall(call.id)
+                        onCallEnded()
+                    }
+                },
+                modifier = Modifier.size(width = 160.dp, height = 52.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF44336))
+            ) {
+                Text("End Call", style = MaterialTheme.typography.titleMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CallControlRow(
+    isMuted: Boolean,
+    isOnHold: Boolean,
+    onMuteToggled: () -> Unit,
+    onHoldToggled: () -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        FilterChip(
+            selected = isMuted,
+            onClick = onMuteToggled,
+            label = { Text(if (isMuted) "Unmute" else "Mute") }
+        )
+        FilterChip(
+            selected = isOnHold,
+            onClick = onHoldToggled,
+            label = { Text(if (isOnHold) "Resume" else "Hold") }
+        )
+    }
+}
+
+@Composable
+private fun AudioRouteSelector(selected: AudioRoute, onRouteSelected: (AudioRoute) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        AudioRoute.entries.forEach { route ->
+            FilterChip(
+                selected = selected == route,
+                onClick = { onRouteSelected(route) },
+                label = { Text(route.label()) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CallStateBadge(state: CallState) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = state.badgeColor().copy(alpha = 0.15f)
+    ) {
+        Text(
+            text = state.name,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = state.badgeColor()
+        )
+    }
+}
+
+@Composable
+private fun ObserveCallState(
+    callManager: CallManager,
+    onCallUpdated: (Call) -> Unit,
+    onCallEnded: (Call) -> Unit
+) {
+    DisposableEffect(callManager) {
+        val callback = object : CallStateCallback {
+            override fun onCallStateChanged(call: Call) {
+                if (call.state == CallState.ENDED) onCallEnded(call) else onCallUpdated(call)
+            }
+            override fun onCallAdded(call: Call) = onCallUpdated(call)
+            override fun onCallRemoved(call: Call) = onCallEnded(call)
+        }
+        callManager.registerCallStateCallback(callback)
+        onDispose { callManager.unregisterCallStateCallback(callback) }
+    }
+}
+
+private fun CoroutineScope.placeCallWithPermissionCheck(
+    number: String,
+    callManager: CallManager,
+    permissionsController: PermissionsController,
+    onError: (String) -> Unit
+) {
+    launch {
+        try {
+            when (permissionsController.getPermissionState(Permission.CALL_PHONE)) {
+                PermissionState.Granted -> callManager.startOutgoingCall(number, number)
+                PermissionState.DeniedAlways -> permissionsController.openAppSettings()
+                else -> {
+                    permissionsController.providePermission(Permission.CALL_PHONE)
+                    callManager.startOutgoingCall(number, number)
+                }
+            }
+        } catch (e: DeniedAlwaysException) {
+            permissionsController.openAppSettings()
+        } catch (e: DeniedException) {
+            onError("Call permission is required to place a call.")
+        } catch (e: Exception) {
+            onError(e.message ?: "Failed to place call.")
+        }
+    }
+}
+
+private fun CallState.badgeColor(): Color = when (this) {
+    CallState.DIALING -> Color(0xFF2196F3)
+    CallState.RINGING -> Color(0xFFFF9800)
+    CallState.ACTIVE  -> Color(0xFF4CAF50)
+    CallState.HOLDING -> Color(0xFF9E9E9E)
+    CallState.ENDED   -> Color(0xFFF44336)
+}
+
+private fun AudioRoute.label(): String = when (this) {
+    AudioRoute.SPEAKER       -> "Speaker"
+    AudioRoute.EARPIECE      -> "Earpiece"
+    AudioRoute.BLUETOOTH     -> "BT"
+    AudioRoute.WIRED_HEADSET -> "Headset"
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/AudioRoute.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/AudioRoute.kt
@@ -1,15 +1,8 @@
 package io.jadu.ringlr.call
 
-/**
- * Represents possible audio routing options for calls.
- */
 enum class AudioRoute {
-    SPEAKER,        // Phone's loudspeaker
-    EARPIECE,       // Phone's earpiece
-    BLUETOOTH,      // Connected Bluetooth device
-    WIRED_HEADSET  // Wired headphones or headset
-}
-
-interface AudioRouteCallback {
-    fun onAudioRouteChanged(route: AudioRoute)
+    SPEAKER,
+    EARPIECE,
+    BLUETOOTH,
+    WIRED_HEADSET
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/AudioRouteCallback.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/AudioRouteCallback.kt
@@ -1,0 +1,11 @@
+package io.jadu.ringlr.call
+
+/**
+ * Notified whenever the active audio output route changes during a call.
+ *
+ * Route changes can be triggered by the user, by connecting/disconnecting
+ * a headset or Bluetooth device, or by the platform reclaiming the session.
+ */
+interface AudioRouteCallback {
+    fun onAudioRouteChanged(route: AudioRoute)
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/Call.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/Call.kt
@@ -1,12 +1,10 @@
 package io.jadu.ringlr.call
 
 /**
- * Represents a call in the system with its associated properties.
- * @property id Unique identifier for the call
- * @property number The phone number associated with the call
- * @property displayName The display name of the contact if available
- * @property state Current state of the call
- * @property createdAt Timestamp when the call was created
+ * Immutable snapshot of a call at a point in time.
+ *
+ * Every state change produces a new [Call] instance. The [id] maps to the
+ * platform call handle — NSUUID string on iOS, connection tag on Android.
  */
 data class Call(
     val id: String,

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallError.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallError.kt
@@ -1,23 +1,19 @@
 package io.jadu.ringlr.call
 
 /**
- * Represents possible errors that can occur during call operations.
- * This sealed class hierarchy provides type-safe error handling across platforms.
+ * Represents every failure case that can arise during a call operation.
+ *
+ * Extends [Exception] so it can be thrown inside coroutines and caught
+ * naturally, while still being returnable inside [CallResult.Error] for
+ * callers that prefer result-style error handling.
  */
 sealed class CallError : Exception() {
-    // io.jadu.ringlr.permission.Permission-related errors
     data class PermissionDenied(override val message: String) : CallError()
-    data class MissingPermission(val permission: String) : CallError()
-
-    // Call state errors
+    data class MissingPermission(val permissionName: String) : CallError()
     data class InvalidCallState(val currentState: CallState, val requestedOperation: String) : CallError()
     data class CallNotFound(val callId: String) : CallError()
-
-    // Device/hardware errors
     data class AudioDeviceError(override val message: String) : CallError()
     data class NetworkError(override val message: String) : CallError()
-
-    // Service errors
     data class ServiceNotInitialized(override val message: String) : CallError()
     data class ServiceError(override val message: String, val code: Int) : CallError()
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallHandler.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallHandler.kt
@@ -1,20 +1,17 @@
 package io.jadu.ringlr.call
 
-
 /**
- * Expected platform-specific configuration class that holds essential platform settings.
- * Android: Will contain Context and necessary Android-specific configurations
- * iOS: Will contain CallKit and AVAudioSession configurations
+ * Holds the platform-specific runtime dependencies needed to initialise the calling stack.
+ *
+ * On Android this wraps TelecomManager and handles phone account registration.
+ * On iOS this owns the single CXProvider and AVAudioSession required by CallKit.
+ *
+ * Always create via [PlatformConfiguration.create] and call [initializeCallConfiguration]
+ * before constructing a [CallManager].
  */
 expect class PlatformConfiguration {
-
-    // Platform-specific initialization
     fun initializeCallConfiguration()
-
-    // Custom Call Configuration
-    fun initializeCustomCallConfiguration(setHighlightColor:Int, setDescription:String, setSupportedUriSchemes:List<String>)
-
-    // Platform-specific cleanup
+    fun initializeCustomCallConfiguration(setHighlightColor: Int, setDescription: String, setSupportedUriSchemes: List<String>)
     fun cleanupCallConfiguration()
 
     companion object {
@@ -22,33 +19,26 @@ expect class PlatformConfiguration {
     }
 }
 
-
 /**
- * Expected CallManager implementation that bridges to platform-specific calling APIs.
- * Android: Implements using Telecom framework
- * iOS: Implements using CallKit
+ * Entry point for all call operations in Ringlr.
+ *
+ * Bridges the shared [CallManagerInterface] to the platform calling API —
+ * Android Telecom on Android, CallKit on iOS. Construct with a fully
+ * initialised [PlatformConfiguration].
+ *
+ * All suspend functions are safe to call from any coroutine context.
+ * Register a [CallStateCallback] to receive real-time call lifecycle events.
  */
-expect class CallManager(configuration: PlatformConfiguration) :
-    CallManagerInterface {
-
-    // Call State Management
-    override suspend fun startOutgoingCall(number: String, displayName: String,scheme:String): CallResult<Call>
+expect class CallManager(configuration: PlatformConfiguration) : CallManagerInterface {
+    override suspend fun startOutgoingCall(number: String, displayName: String, scheme: String): CallResult<Call>
     override suspend fun endCall(callId: String): CallResult<Unit>
     override suspend fun muteCall(callId: String, muted: Boolean): CallResult<Unit>
     override suspend fun holdCall(callId: String, onHold: Boolean): CallResult<Unit>
-
-    // Call Information
     override suspend fun getCallState(callId: String): CallResult<CallState>
     override suspend fun getActiveCalls(): CallResult<List<Call>>
-
-    // Audio Route Management
     override suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit>
     override suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
-
-    // io.jadu.ringlr.permission.Permission Management
     override suspend fun checkPermissions(): CallResult<Unit>
-
-    // Callback Registration
     override fun registerCallStateCallback(callback: CallStateCallback)
     override fun unregisterCallStateCallback(callback: CallStateCallback)
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallManagerInterface.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallManagerInterface.kt
@@ -1,60 +1,27 @@
 package io.jadu.ringlr.call
 
-
-
 /**
- * Main interface for managing calls across platforms.
- * This interface provides a unified API for handling calls on both Android and iOS.
+ * Defines the contract for managing phone calls across platforms.
+ *
+ * All operations return a [CallResult] so callers can handle success and
+ * failure without exceptions leaking through the API boundary.
+ * Each function targets a specific call by its [Call.id].
  */
 interface CallManagerInterface {
-    /**
-     * Initiates an outgoing call to the specified number.
-     * @param number The phone number to call
-     * @param displayName The name to display for the call
-     * @param scheme The scheme to use for the call - e.g "tel", "sip", etc.
-     * tel is used for normal phone calls and sip is used for VoIP calls and other custom schemes
-     * @return CallResult containing the Call object if successful
-     */
-    suspend fun startOutgoingCall(number: String, displayName: String, scheme:String = "tel"): CallResult<Call>
+    suspend fun startOutgoingCall(
+        number: String,
+        displayName: String,
+        scheme: String = "tel"
+    ): CallResult<Call>
 
-    /**
-     * Ends an active call.
-     * @param callId The ID of the call to end
-     */
     suspend fun endCall(callId: String): CallResult<Unit>
-
-    /**
-     * Mutes or unmutes an active call.
-     * @param callId The ID of the call to mute/unmute
-     * @param muted True to mute, false to unmute
-     */
     suspend fun muteCall(callId: String, muted: Boolean): CallResult<Unit>
-
-    /**
-     * Places a call on hold or resumes it.
-     * @param callId The ID of the call to hold/resume
-     * @param onHold True to hold, false to resume
-     */
     suspend fun holdCall(callId: String, onHold: Boolean): CallResult<Unit>
-
-    /** Gets the current state of a specific call */
     suspend fun getCallState(callId: String): CallResult<CallState>
-
-    /** Gets a list of all active calls in the system */
     suspend fun getActiveCalls(): CallResult<List<Call>>
-
-    /** Changes the audio route for all calls */
     suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit>
-
-    /** Gets the current audio route */
     suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
-
-    /** Checks if all required permissions are granted */
     suspend fun checkPermissions(): CallResult<Unit>
-
-    /** Registers a callback for call state changes */
     fun registerCallStateCallback(callback: CallStateCallback)
-
-    /** Unregisters a previously registered callback */
     fun unregisterCallStateCallback(callback: CallStateCallback)
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallResult.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallResult.kt
@@ -1,8 +1,11 @@
 package io.jadu.ringlr.call
 
 /**
- * A generic result type that wraps all operations to handle success and failure cases.
- * @param T The type of the success result
+ * Wraps the outcome of every [CallManagerInterface] operation.
+ *
+ * Use [Success.data] to access the result on the happy path,
+ * or [Error.error] to inspect the typed [CallError] on failure.
+ * Avoids unchecked exceptions crossing the API boundary.
  */
 sealed class CallResult<out T> {
     data class Success<T>(val data: T) : CallResult<T>()

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallState.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallState.kt
@@ -1,12 +1,9 @@
 package io.jadu.ringlr.call
 
-/**
- * Represents the current state of a call in the system.
- */
 enum class CallState {
-    DIALING,    // Outgoing call is being established
-    RINGING,    // Incoming call is ringing
-    ACTIVE,     // Call is connected and active
-    HOLDING,    // Call is on hold
-    ENDED       // Call has ended
+    DIALING,
+    RINGING,
+    ACTIVE,
+    HOLDING,
+    ENDED
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallStateCallback.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallStateCallback.kt
@@ -1,8 +1,10 @@
 package io.jadu.ringlr.call
 
-
 /**
- * Interface for receiving updates about call state changes.
+ * Receives real-time call lifecycle events from [CallManager].
+ *
+ * Register via [CallManagerInterface.registerCallStateCallback] and always
+ * unregister when done to avoid memory leaks.
  */
 interface CallStateCallback {
     fun onCallStateChanged(call: Call)

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/ExtendedCallStateCallback.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/ExtendedCallStateCallback.kt
@@ -1,8 +1,10 @@
 package io.jadu.ringlr.call
 
-
 /**
- * Extended callback interface for additional call events
+ * Extends [CallStateCallback] with failure notifications.
+ *
+ * Use this instead of [CallStateCallback] when the caller needs to respond
+ * to error conditions mid-call, such as network drops or hardware faults.
  */
 interface ExtendedCallStateCallback : CallStateCallback {
     fun onCallFailed(call: Call, error: String)

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/MainViewController.kt
@@ -1,0 +1,34 @@
+package io.jadu.ringlr
+
+import androidx.compose.ui.window.ComposeUIViewController
+import io.jadu.ringlr.call.PlatformConfiguration
+import platform.UIKit.UIViewController
+
+/**
+ * Creates the root UIViewController for the iOS host app.
+ *
+ * Call this from your Swift AppDelegate or SwiftUI entry point:
+ *
+ * ```swift
+ * import demoApp
+ *
+ * struct ContentView: View {
+ *     var body: some View {
+ *         MainViewControllerRepresentable()
+ *     }
+ * }
+ *
+ * struct MainViewControllerRepresentable: UIViewControllerRepresentable {
+ *     func makeUIViewController(context: Context) -> UIViewController {
+ *         MainViewControllerKt.MainViewController()
+ *     }
+ *     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+ * }
+ * ```
+ */
+fun MainViewController(): UIViewController {
+    val configuration = PlatformConfiguration.create()
+    return ComposeUIViewController {
+        App(configuration = configuration)
+    }
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/CallHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/CallHandler.ios.kt
@@ -1,20 +1,37 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package io.jadu.ringlr.call
 
+import io.jadu.ringlr.call.callkit.ActiveCallRegistry
+import io.jadu.ringlr.call.callkit.CallActionDispatcher
+import io.jadu.ringlr.call.callkit.CallAudioRouter
+import io.jadu.ringlr.call.callkit.SystemCallBridge
+import platform.CallKit.CXEndCallAction
+import platform.CallKit.CXHandle
+import platform.CallKit.CXHandleTypePhoneNumber
+import platform.CallKit.CXSetHeldCallAction
+import platform.CallKit.CXSetMutedCallAction
+import platform.CallKit.CXStartCallAction
+import platform.CallKit.CXTransaction
+import platform.Foundation.NSUUID
+import platform.posix.time
 
-/**
- * Expected platform-specific configuration class that holds essential platform settings.
- * Android: Will contain Context and necessary Android-specific configurations
- * iOS: Will contain CallKit and AVAudioSession configurations
- */
-actual class PlatformConfiguration {
+actual class PlatformConfiguration private constructor() {
 
-    actual fun cleanupCallConfiguration() {
-    }
+    internal val registry = ActiveCallRegistry()
+    internal val audioRouter = CallAudioRouter()
+    internal val callObservers = mutableListOf<CallStateCallback>()
 
-    actual companion object {
-        actual fun create(): PlatformConfiguration {
-            TODO("Not yet implemented")
-        }
+    internal lateinit var systemBridge: SystemCallBridge
+        private set
+
+    internal lateinit var actionDispatcher: CallActionDispatcher
+        private set
+
+    actual fun initializeCallConfiguration() {
+        systemBridge = SystemCallBridge(registry, callObservers)
+        actionDispatcher = CallActionDispatcher()
+        audioRouter.activate()
     }
 
     actual fun initializeCustomCallConfiguration(
@@ -22,73 +39,107 @@ actual class PlatformConfiguration {
         setDescription: String,
         setSupportedUriSchemes: List<String>
     ) {
+        if (!::systemBridge.isInitialized) initializeCallConfiguration()
     }
 
-    actual fun initializeCallConfiguration() {
+    actual fun cleanupCallConfiguration() {
+        if (::systemBridge.isInitialized) systemBridge.provider.invalidate()
+        audioRouter.deactivate()
     }
 
+    actual companion object {
+        actual fun create(): PlatformConfiguration = PlatformConfiguration()
+    }
 }
 
-/**
- * Expected CallManager implementation that bridges to platform-specific calling APIs.
- * Android: Implements using Telecom framework
- * iOS: Implements using CallKit
- */
-actual class CallManager : CallManagerInterface {
-    actual constructor(configuration: PlatformConfiguration) {
-        TODO("Not yet implemented")
-    }
+actual class CallManager actual constructor(
+    private val configuration: PlatformConfiguration
+) : CallManagerInterface {
+
+    private val registry get() = configuration.registry
+    private val audioRouter get() = configuration.audioRouter
+    private val observers get() = configuration.callObservers
+    private val dispatcher get() = configuration.actionDispatcher
 
     actual override suspend fun startOutgoingCall(
         number: String,
         displayName: String,
         scheme: String
-    ): CallResult<Call> {
-        TODO("Not yet implemented")
-    }
+    ): CallResult<Call> = runCatching {
+        val uuid = NSUUID()
+        val call = newCall(uuid, number, displayName)
+        registry.register(call, uuid)
+        observers.forEach { it.onCallAdded(call) }
+        dispatcher.dispatch(startTransaction(uuid, number, displayName))
+        call
+    }.toCallResult()
 
-    actual override suspend fun endCall(callId: String): CallResult<Unit> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun endCall(callId: String): CallResult<Unit> = runCatching {
+        val uuid = registry.uuidFor(callId) ?: throw CallError.CallNotFound(callId)
+        dispatcher.dispatch(CXTransaction(action = CXEndCallAction(callUUID = uuid)))
+    }.toCallResult()
 
-    actual override suspend fun muteCall(
-        callId: String,
-        muted: Boolean
-    ): CallResult<Unit> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun muteCall(callId: String, muted: Boolean): CallResult<Unit> = runCatching {
+        val uuid = registry.uuidFor(callId) ?: throw CallError.CallNotFound(callId)
+        dispatcher.dispatch(CXTransaction(action = CXSetMutedCallAction(callUUID = uuid, muted = muted)))
+    }.toCallResult()
 
-    actual override suspend fun holdCall(
-        callId: String,
-        onHold: Boolean
-    ): CallResult<Unit> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun holdCall(callId: String, onHold: Boolean): CallResult<Unit> = runCatching {
+        val uuid = registry.uuidFor(callId) ?: throw CallError.CallNotFound(callId)
+        dispatcher.dispatch(CXTransaction(action = CXSetHeldCallAction(callUUID = uuid, onHold = onHold)))
+    }.toCallResult()
 
     actual override suspend fun getCallState(callId: String): CallResult<CallState> {
-        TODO("Not yet implemented")
+        val call = registry.findById(callId) ?: return CallResult.Error(CallError.CallNotFound(callId))
+        return CallResult.Success(call.state)
     }
 
-    actual override suspend fun getActiveCalls(): CallResult<List<Call>> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun getActiveCalls(): CallResult<List<Call>> =
+        CallResult.Success(registry.allActive())
 
     actual override suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit> {
-        TODO("Not yet implemented")
+        val routed = audioRouter.routeTo(route)
+        return if (routed) CallResult.Success(Unit)
+        else CallResult.Error(CallError.AudioDeviceError("Cannot route audio to $route"))
     }
 
-    actual override suspend fun getCurrentAudioRoute(): CallResult<AudioRoute> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun getCurrentAudioRoute(): CallResult<AudioRoute> =
+        CallResult.Success(audioRouter.currentRoute())
 
-    actual override suspend fun checkPermissions(): CallResult<Unit> {
-        TODO("Not yet implemented")
-    }
+    actual override suspend fun checkPermissions(): CallResult<Unit> =
+        CallResult.Success(Unit)
 
     actual override fun registerCallStateCallback(callback: CallStateCallback) {
+        observers.add(callback)
     }
 
     actual override fun unregisterCallStateCallback(callback: CallStateCallback) {
+        observers.remove(callback)
     }
 
+    private fun newCall(uuid: NSUUID, number: String, displayName: String) = Call(
+        id = uuid.UUIDString,
+        number = number,
+        displayName = displayName,
+        state = CallState.DIALING,
+        createdAt = time(null)
+    )
+
+    private fun startTransaction(uuid: NSUUID, number: String, displayName: String): CXTransaction {
+        val handle = CXHandle(type = CXHandleTypePhoneNumber, value = number)
+        val action = CXStartCallAction(callUUID = uuid, handle = handle).apply {
+            contactIdentifier = displayName
+        }
+        return CXTransaction(action = action)
+    }
 }
+
+private fun <T> Result<T>.toCallResult(): CallResult<T> = fold(
+    onSuccess = { CallResult.Success(it) },
+    onFailure = { error ->
+        when (error) {
+            is CallError -> CallResult.Error(error)
+            else -> CallResult.Error(CallError.ServiceError(error.message ?: "Unexpected error", -1))
+        }
+    }
+)

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/ActiveCallRegistry.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/ActiveCallRegistry.kt
@@ -1,0 +1,45 @@
+package io.jadu.ringlr.call.callkit
+
+import io.jadu.ringlr.call.Call
+import io.jadu.ringlr.call.CallState
+import platform.Foundation.NSUUID
+
+/**
+ * Tracks all in-flight calls, bridging the domain callId (String) to the
+ * system UUID (NSUUID) that CallKit requires for every action.
+ */
+internal class ActiveCallRegistry {
+
+    private val callsById = mutableMapOf<String, Call>()
+    private val uuidToCallId = mutableMapOf<String, String>()
+
+    fun register(call: Call, uuid: NSUUID) {
+        callsById[call.id] = call
+        uuidToCallId[uuid.UUIDString] = call.id
+    }
+
+    fun findById(callId: String): Call? = callsById[callId]
+
+    fun findByUUID(uuid: NSUUID): Call? =
+        uuidToCallId[uuid.UUIDString]?.let { callsById[it] }
+
+    fun uuidFor(callId: String): NSUUID? {
+        val uuidString = uuidToCallId.entries
+            .firstOrNull { it.value == callId }
+            ?.key ?: return null
+        return NSUUID(uUIDString = uuidString)
+    }
+
+    fun transition(callId: String, to: CallState): Call? {
+        val updated = callsById[callId]?.copy(state = to) ?: return null
+        callsById[callId] = updated
+        return updated
+    }
+
+    fun remove(callId: String) {
+        callsById.remove(callId)
+        uuidToCallId.entries.removeAll { it.value == callId }
+    }
+
+    fun allActive(): List<Call> = callsById.values.toList()
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallActionDispatcher.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallActionDispatcher.kt
@@ -1,0 +1,28 @@
+package io.jadu.ringlr.call.callkit
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.CallKit.CXCallController
+import platform.CallKit.CXTransaction
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Submits call actions to the system via CXCallController.
+ *
+ * CallKit validates each action and routes it back through [SystemCallBridge]
+ * if approved. This class is the outgoing channel only — it never modifies state.
+ */
+internal class CallActionDispatcher {
+
+    private val controller = CXCallController()
+
+    suspend fun dispatch(transaction: CXTransaction) {
+        suspendCancellableCoroutine { continuation ->
+            controller.requestTransaction(transaction) { error ->
+                if (!continuation.isActive) return@requestTransaction
+                if (error == null) continuation.resume(Unit)
+                else continuation.resumeWithException(Exception(error.localizedDescription))
+            }
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallAudioRouter.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallAudioRouter.kt
@@ -1,0 +1,73 @@
+package io.jadu.ringlr.call.callkit
+
+import io.jadu.ringlr.call.AudioRoute
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
+import platform.AVFAudio.AVAudioSessionPortBluetoothA2DP
+import platform.AVFAudio.AVAudioSessionPortBluetoothHFP
+import platform.AVFAudio.AVAudioSessionPortBuiltInSpeaker
+import platform.AVFAudio.AVAudioSessionPortDescription
+import platform.AVFAudio.AVAudioSessionPortHeadphones
+import platform.AVFAudio.AVAudioSessionPortOverrideNone
+import platform.AVFAudio.AVAudioSessionPortOverrideSpeaker
+
+/**
+ * Routes audio output for an active call using AVAudioSession.
+ *
+ * The session must be active (CallKit activates it automatically during a call
+ * via provider(_:didActivate:)) before routing calls are meaningful.
+ */
+internal class CallAudioRouter {
+
+    private val session: AVAudioSession get() = AVAudioSession.sharedInstance()
+
+    fun activate() {
+        session.setCategory(AVAudioSessionCategoryPlayAndRecord, error = null)
+        session.setActive(true, error = null)
+    }
+
+    fun deactivate() {
+        session.setActive(false, error = null)
+    }
+
+    fun routeTo(destination: AudioRoute): Boolean = when (destination) {
+        AudioRoute.SPEAKER -> overrideToSpeaker()
+        AudioRoute.EARPIECE -> overrideToEarpiece()
+        AudioRoute.BLUETOOTH -> routeToBluetoothHeadset()
+        AudioRoute.WIRED_HEADSET -> routeToWiredHeadset()
+    }
+
+    fun currentRoute(): AudioRoute {
+        val outputs = session.currentRoute.outputs.filterIsInstance<AVAudioSessionPortDescription>()
+        return when {
+            outputs.any { it.portType == AVAudioSessionPortBuiltInSpeaker } -> AudioRoute.SPEAKER
+            outputs.any { it.isBluetooth() } -> AudioRoute.BLUETOOTH
+            outputs.any { it.portType == AVAudioSessionPortHeadphones } -> AudioRoute.WIRED_HEADSET
+            else -> AudioRoute.EARPIECE
+        }
+    }
+
+    private fun overrideToSpeaker(): Boolean =
+        session.overrideOutputAudioPort(AVAudioSessionPortOverrideSpeaker, error = null)
+
+    private fun overrideToEarpiece(): Boolean =
+        session.overrideOutputAudioPort(AVAudioSessionPortOverrideNone, error = null)
+
+    private fun routeToBluetoothHeadset(): Boolean {
+        val port = findInput(AVAudioSessionPortBluetoothHFP) ?: return false
+        return session.setPreferredInput(port, error = null)
+    }
+
+    private fun routeToWiredHeadset(): Boolean {
+        val port = findInput(AVAudioSessionPortHeadphones) ?: return false
+        return session.setPreferredInput(port, error = null)
+    }
+
+    private fun findInput(portType: String): AVAudioSessionPortDescription? =
+        session.availableInputs
+            ?.filterIsInstance<AVAudioSessionPortDescription>()
+            ?.firstOrNull { it.portType == portType }
+
+    private fun AVAudioSessionPortDescription.isBluetooth(): Boolean =
+        portType == AVAudioSessionPortBluetoothHFP || portType == AVAudioSessionPortBluetoothA2DP
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/SystemCallBridge.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/SystemCallBridge.kt
@@ -1,0 +1,123 @@
+package io.jadu.ringlr.call.callkit
+
+import io.jadu.ringlr.call.Call
+import io.jadu.ringlr.call.CallState
+import io.jadu.ringlr.call.CallStateCallback
+import platform.CallKit.CXAnswerCallAction
+import platform.CallKit.CXCallUpdate
+import platform.CallKit.CXEndCallAction
+import platform.CallKit.CXHandle
+import platform.CallKit.CXHandleTypePhoneNumber
+import platform.CallKit.CXProvider
+import platform.CallKit.CXProviderConfiguration
+import platform.CallKit.CXProviderDelegateProtocol
+import platform.CallKit.CXSetHeldCallAction
+import platform.CallKit.CXSetMutedCallAction
+import platform.CallKit.CXStartCallAction
+import platform.Foundation.NSObject
+import platform.Foundation.NSUUID
+import platform.darwin.dispatch_get_main_queue
+
+/**
+ * Bridges CallKit system events into domain [CallStateCallback] notifications.
+ *
+ * Owns the single [CXProvider] instance (CallKit requires one per app).
+ * Translates each system action into a [CallState] transition and
+ * notifies all registered observers.
+ */
+internal class SystemCallBridge(
+    private val registry: ActiveCallRegistry,
+    private val observers: MutableList<CallStateCallback>,
+    appName: String = "Ringlr"
+) : NSObject(), CXProviderDelegateProtocol {
+
+    val provider: CXProvider = buildProvider(appName)
+
+    init {
+        provider.setDelegate(this, queue = dispatch_get_main_queue())
+    }
+
+    fun reportIncomingCall(uuid: NSUUID, call: Call) {
+        registry.register(call, uuid)
+        provider.reportNewIncomingCallWithUUID(uuid, update = buildCallUpdate(call)) { error ->
+            if (error != null) return@reportNewIncomingCallWithUUID
+            val ringing = registry.transition(call.id, CallState.RINGING) ?: return@reportNewIncomingCallWithUUID
+            observers.forEach { it.onCallAdded(ringing) }
+            observers.forEach { it.onCallStateChanged(ringing) }
+        }
+    }
+
+    override fun providerDidReset(provider: CXProvider) {
+        registry.allActive().forEach { call ->
+            val ended = registry.transition(call.id, CallState.ENDED) ?: return@forEach
+            notifyEnded(ended)
+            registry.remove(call.id)
+        }
+    }
+
+    override fun provider(provider: CXProvider, performStartCallAction: CXStartCallAction) {
+        val call = registry.findByUUID(performStartCallAction.callUUID)
+        if (call != null) {
+            val dialing = registry.transition(call.id, CallState.DIALING)
+            dialing?.let { observers.forEach { cb -> cb.onCallStateChanged(it) } }
+            provider.reportOutgoingCallWithUUID(performStartCallAction.callUUID, startedConnectingAtDate = null)
+        }
+        performStartCallAction.fulfill()
+    }
+
+    override fun provider(provider: CXProvider, performAnswerCallAction: CXAnswerCallAction) {
+        transitionAndNotify(performAnswerCallAction.callUUID, CallState.ACTIVE)
+        performAnswerCallAction.fulfill()
+    }
+
+    override fun provider(provider: CXProvider, performEndCallAction: CXEndCallAction) {
+        val call = registry.findByUUID(performEndCallAction.callUUID)
+        if (call != null) {
+            val ended = registry.transition(call.id, CallState.ENDED)
+            ended?.let { notifyEnded(it) }
+            registry.remove(call.id)
+        }
+        performEndCallAction.fulfill()
+    }
+
+    override fun provider(provider: CXProvider, performSetMutedCallAction: CXSetMutedCallAction) {
+        performSetMutedCallAction.fulfill()
+    }
+
+    override fun provider(provider: CXProvider, performSetHeldCallAction: CXSetHeldCallAction) {
+        val nextState = if (performSetHeldCallAction.onHold) CallState.HOLDING else CallState.ACTIVE
+        transitionAndNotify(performSetHeldCallAction.callUUID, nextState)
+        performSetHeldCallAction.fulfill()
+    }
+
+    private fun transitionAndNotify(uuid: NSUUID, state: CallState) {
+        val call = registry.findByUUID(uuid) ?: return
+        val updated = registry.transition(call.id, state) ?: return
+        observers.forEach { it.onCallStateChanged(updated) }
+    }
+
+    private fun notifyEnded(call: Call) {
+        observers.forEach { it.onCallStateChanged(call) }
+        observers.forEach { it.onCallRemoved(call) }
+    }
+
+    private fun buildCallUpdate(call: Call): CXCallUpdate =
+        CXCallUpdate().apply {
+            remoteHandle = CXHandle(type = CXHandleTypePhoneNumber, value = call.number)
+            localizedCallerName = call.displayName
+            supportsHolding = true
+            supportsDTMF = false
+            supportsGrouping = false
+            supportsUngrouping = false
+        }
+
+    private fun buildProvider(appName: String): CXProvider {
+        val config = CXProviderConfiguration().apply {
+            localizedName = appName
+            supportsVideo = false
+            maximumCallGroups = 1u
+            maximumCallsPerCallGroup = 1u
+        }
+        return CXProvider(configuration = config)
+    }
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/AlwaysGrantedDelegate.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/AlwaysGrantedDelegate.kt
@@ -1,0 +1,18 @@
+package io.jadu.ringlr.permission.delegate
+
+import io.jadu.ringlr.permission.PermissionDelegate
+import io.jadu.ringlr.permission.PermissionState
+
+/**
+ * Delegate for permissions that have no iOS equivalent.
+ *
+ * On Android, permissions like CALL_PHONE guard access to the Telecom API.
+ * On iOS, CallKit manages call access at the system level — no runtime grant
+ * is required from the app. Reporting Granted avoids blocking the iOS call flow.
+ */
+internal object AlwaysGrantedDelegate : PermissionDelegate {
+
+    override suspend fun providePermission() = Unit
+
+    override suspend fun getPermissionState(): PermissionState = PermissionState.Granted
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/AudioPermission.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/AudioPermission.ios.kt
@@ -2,9 +2,11 @@ package io.jadu.ringlr.permission.delegate
 
 import io.jadu.ringlr.permission.PermissionDelegate
 
-internal actual val modifyAudioSettingsDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val recordAudioDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val microphoneDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
+/**
+ * MODIFY_AUDIO_SETTINGS has no iOS equivalent — AVAudioSession configuration
+ * is unrestricted. RECORD_AUDIO and MICROPHONE both map to the microphone
+ * access prompt via AVAudioSession.
+ */
+internal actual val modifyAudioSettingsDelegate: PermissionDelegate get() = AlwaysGrantedDelegate
+internal actual val recordAudioDelegate: PermissionDelegate get() = MicrophonePermissionDelegate()
+internal actual val microphoneDelegate: PermissionDelegate get() = MicrophonePermissionDelegate()

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermission.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermission.ios.kt
@@ -2,7 +2,9 @@ package io.jadu.ringlr.permission.delegate
 
 import io.jadu.ringlr.permission.PermissionDelegate
 
-internal actual val bluetoothDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val bluetoothConnectDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
+/**
+ * Both BLUETOOTH and BLUETOOTH_CONNECT map to CBCentralManager authorization on iOS.
+ * The OS presents a single Bluetooth access prompt for both use cases.
+ */
+internal actual val bluetoothDelegate: PermissionDelegate get() = BluetoothPermissionDelegate()
+internal actual val bluetoothConnectDelegate: PermissionDelegate get() = BluetoothPermissionDelegate()

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermissionDelegate.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermissionDelegate.kt
@@ -1,0 +1,60 @@
+package io.jadu.ringlr.permission.delegate
+
+import io.jadu.ringlr.permission.DeniedAlwaysException
+import io.jadu.ringlr.permission.DeniedException
+import io.jadu.ringlr.permission.PermissionDelegate
+import io.jadu.ringlr.permission.PermissionState
+import io.jadu.ringlr.permission.delegate.BluetoothPermission
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
+import platform.CoreBluetooth.CBManagerAuthorization
+import platform.CoreBluetooth.CBManagerAuthorizationAllowedAlways
+import platform.CoreBluetooth.CBManagerAuthorizationDenied
+import platform.CoreBluetooth.CBManagerAuthorizationNotDetermined
+import platform.CoreBluetooth.CBManagerAuthorizationRestricted
+import platform.Foundation.NSObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Requests and checks Bluetooth access via CBCentralManager (iOS 13+).
+ *
+ * Instantiating a CBCentralManager is what triggers the system authorization
+ * prompt when status is NotDetermined. The delegate observes state changes.
+ */
+internal class BluetoothPermissionDelegate : PermissionDelegate {
+
+    override suspend fun getPermissionState(): PermissionState =
+        cbAuthorizationToPermissionState(CBCentralManager.authorization())
+
+    override suspend fun providePermission() {
+        val current = getPermissionState()
+        if (current == PermissionState.Granted) return
+        if (current == PermissionState.DeniedAlways) throw DeniedAlwaysException(BluetoothPermission)
+
+        requestBluetoothAccess()
+
+        val result = getPermissionState()
+        if (result != PermissionState.Granted) throw DeniedException(BluetoothPermission)
+    }
+
+    private suspend fun requestBluetoothAccess() {
+        suspendCancellableCoroutine { continuation ->
+            val observer = object : NSObject(), CBCentralManagerDelegateProtocol {
+                override fun centralManagerDidUpdateState(central: CBCentralManager) {
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+            }
+            CBCentralManager(delegate = observer, queue = null)
+        }
+    }
+
+    private fun cbAuthorizationToPermissionState(authorization: CBManagerAuthorization): PermissionState =
+        when (authorization) {
+            CBManagerAuthorizationAllowedAlways -> PermissionState.Granted
+            CBManagerAuthorizationDenied, CBManagerAuthorizationRestricted -> PermissionState.DeniedAlways
+            CBManagerAuthorizationNotDetermined -> PermissionState.NotDetermined
+            else -> PermissionState.NotDetermined
+        }
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/CallPermission.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/CallPermission.ios.kt
@@ -2,14 +2,12 @@ package io.jadu.ringlr.permission.delegate
 
 import io.jadu.ringlr.permission.PermissionDelegate
 
-//TODO:: Implement this
-internal actual val callDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val manageCallDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val readPhoneStateDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val answerPhoneCallDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
-internal actual val readPhoneNumbersDelegate: PermissionDelegate
-    get() = TODO("Not yet implemented")
+/**
+ * iOS has no runtime equivalents for Android's telephony permissions.
+ * CallKit manages call access at the system level — no grant needed from the app.
+ */
+internal actual val callDelegate: PermissionDelegate get() = AlwaysGrantedDelegate
+internal actual val manageCallDelegate: PermissionDelegate get() = AlwaysGrantedDelegate
+internal actual val readPhoneStateDelegate: PermissionDelegate get() = AlwaysGrantedDelegate
+internal actual val answerPhoneCallDelegate: PermissionDelegate get() = AlwaysGrantedDelegate
+internal actual val readPhoneNumbersDelegate: PermissionDelegate get() = AlwaysGrantedDelegate

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/MicrophonePermissionDelegate.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/MicrophonePermissionDelegate.kt
@@ -1,0 +1,47 @@
+package io.jadu.ringlr.permission.delegate
+
+import io.jadu.ringlr.permission.DeniedAlwaysException
+import io.jadu.ringlr.permission.DeniedException
+import io.jadu.ringlr.permission.PermissionDelegate
+import io.jadu.ringlr.permission.PermissionState
+import io.jadu.ringlr.permission.delegate.MicrophonePermission
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionRecordPermissionDenied
+import platform.AVFAudio.AVAudioSessionRecordPermissionGranted
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Requests and checks microphone access via AVAudioSession.
+ *
+ * Used for RECORD_AUDIO and MICROPHONE permissions. Both map to the same
+ * underlying iOS permission — the microphone access prompt.
+ */
+internal class MicrophonePermissionDelegate : PermissionDelegate {
+
+    private val session: AVAudioSession get() = AVAudioSession.sharedInstance()
+
+    override suspend fun getPermissionState(): PermissionState =
+        when (session.recordPermission) {
+            AVAudioSessionRecordPermissionGranted -> PermissionState.Granted
+            AVAudioSessionRecordPermissionDenied -> PermissionState.DeniedAlways
+            else -> PermissionState.NotDetermined
+        }
+
+    override suspend fun providePermission() {
+        val current = getPermissionState()
+        if (current == PermissionState.Granted) return
+        if (current == PermissionState.DeniedAlways) throw DeniedAlwaysException(MicrophonePermission)
+
+        val granted = requestMicrophoneAccess()
+        if (!granted) throw DeniedException(MicrophonePermission)
+    }
+
+    private suspend fun requestMicrophoneAccess(): Boolean =
+        suspendCancellableCoroutine { continuation ->
+            session.requestRecordPermission { granted ->
+                if (continuation.isActive) continuation.resume(granted)
+            }
+        }
+}


### PR DESCRIPTION
- Implement PlatformConfiguration for iOS with CXProvider, AVAudioSession, and CallKit lifecycle (initializeCallConfiguration, cleanup)
- Add CallKit support classes: ActiveCallRegistry, CallActionDispatcher, CallAudioRouter, and SystemCallBridge for bridging CX actions to shared state
- Implement actual CallManager for iOS: outgoing/incoming call handling, mute, hold, audio routing, and DTMF via CallKit transactions
- Refactor shared CallHandler, CallManagerInterface, CallState, CallError, CallResult, AudioRoute, and callbacks for cleaner API surface
- Add iOS permission delegates: Audio, Bluetooth, Call, Microphone, and AlwaysGranted fallback
- Add MainViewController entry point for iOS Compose UI
- Update README with revised documentation and usage examples
- Bump gradle deps and enable demoApp module in settings