### PR TITLE
Add SIP support and VoIP push notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ringlr is a Kotlin Multiplatform Mobile (KMM) library for handling phone calls a
 - Make and manage outgoing phone calls
 - Answer incoming calls (via system UI)
 - Mute, hold, and end active calls
-- Route audio to speaker, earpiece, Bluetooth, or wired headset
+- Route audio to speaker or earpiece; iOS auto-routes to connected Bluetooth/wired headset
 - Request and check call and microphone permissions
 - Real-time call state callbacks
 - Android Telecom framework integration
@@ -36,9 +36,107 @@ Ringlr is a Kotlin Multiplatform Mobile (KMM) library for handling phone calls a
 
 ---
 
+## VoIP / SIP Support
+
+Ringlr provides the **UI and call lifecycle layer** for VoIP/SIP calls — it does not bundle a SIP stack or media engine.
+
+### How it works
+
+| Layer | Ringlr's role | Your responsibility |
+|---|---|---|
+| System call UI (CallKit / Telecom) | Handled by Ringlr | — |
+| Call state (dialing, active, hold, end) | Handled by Ringlr | — |
+| SIP signaling (REGISTER, INVITE, BYE) | Not included | Your SIP stack |
+| Media / audio (RTP, codecs, SRTP) | Not included | Your SIP stack |
+
+### Android
+
+Android removed its built-in `SipManager` API in **Android 12 (API 31)** with no official replacement.
+
+On **API ≤ 30**, Ringlr uses the system `SipManager` automatically after `configureSipAccount()`.
+
+On **API 31+**, `configureSipAccount()` returns `CallError.SipUnsupported`. The recommended flow:
+
+1. Establish your session with a SIP/VoIP library (Linphone, PJSIP, WebRTC, etc.)
+2. Once connected, call `startOutgoingCall(number, displayName, scheme = "sip")` so Ringlr registers the call with the Telecom framework and shows system UI
+
+### iOS
+
+CallKit is transport-agnostic — it shows the system call UI regardless of the underlying protocol. `configureSipAccount()` on iOS stores the profile for your use; CallKit handles the UI automatically via `startOutgoingCall(scheme = "sip")`.
+
+### VoIP vs SIP
+
+- **VoIP** — any voice call over the internet (WhatsApp, FaceTime, Zoom are all VoIP)
+- **SIP** — one open protocol for VoIP (what `scheme = "sip"` targets)
+- **WebRTC** — another common VoIP protocol; not covered by the SIP scheme
+
+---
+
+## VoIP Push Notifications
+
+VoIP push wakes the app for an incoming call even when it is suspended. Without it, iOS will not display the incoming call screen reliably.
+
+### iOS (PushKit — automatic)
+
+```kotlin
+val registrar = VoipPushRegistrar(platformConfig)
+registrar.register(object : VoipPushListener {
+    override fun onTokenRefreshed(token: String) {
+        // Send token to your push server
+    }
+    override fun onIncomingCall(payload: VoipPushPayload) {
+        // CallKit system UI is already shown by Ringlr.
+        // Use payload for your own in-app handling if needed.
+    }
+})
+```
+
+PushKit delivers the push directly to the delegate. Ringlr calls `reportIncomingCall` on CallKit automatically — no extra steps needed.
+
+Expected push payload keys from your server:
+
+| Key | Value |
+|---|---|
+| `call_id` | Unique call identifier |
+| `caller_number` | Phone number or SIP address |
+| `caller_name` | Display name |
+| `scheme` | `"sip"` or `"tel"` |
+
+### Android (FCM — app bridges to Ringlr)
+
+```kotlin
+// In Application.onCreate
+val registrar = VoipPushRegistrar(platformConfig)
+registrar.register(object : VoipPushListener {
+    override fun onTokenRefreshed(token: String) { sendToServer(token) }
+    override fun onIncomingCall(payload: VoipPushPayload) { /* show in-app UI */ }
+})
+
+// In your FirebaseMessagingService
+override fun onNewToken(token: String) {
+    registrar.handleTokenRefresh(token)
+}
+
+override fun onMessageReceived(message: RemoteMessage) {
+    if (message.data["type"] == "voip") {
+        registrar.handleVoipPush(
+            VoipPushPayload(
+                callId       = message.data["call_id"]       ?: "",
+                callerNumber = message.data["caller_number"] ?: "",
+                callerName   = message.data["caller_name"]   ?: "Unknown",
+                scheme       = message.data["scheme"]        ?: "sip"
+            )
+        )
+    }
+}
+```
+
+Ringlr notifies `onIncomingCall` and registers the call with the Telecom framework for the system call log. Add `MANAGE_OWN_CALLS` to your manifest for the system call screen to appear.
+
+---
+
 ## Upcoming Changes
 
-- ✨ VoIP / SIP support
 - ✨ Custom in-app calling UI
 - ✨ Publishing on Maven Central
 
@@ -117,6 +215,8 @@ suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
 
 `AudioRoute` values: `SPEAKER`, `EARPIECE`, `BLUETOOTH`, `WIRED_HEADSET`
 
+> **iOS note:** `SPEAKER` and `EARPIECE` are controlled via `AVAudioSession` port override. For `BLUETOOTH` and `WIRED_HEADSET`, iOS automatically routes to any connected device when the speaker override is removed — no additional API call is required. Use `AVRoutePickerView` for fine-grained Bluetooth device selection.
+
 ### Callbacks
 
 ```kotlin
@@ -166,7 +266,7 @@ shared/
                 ├── ActiveCallRegistry.kt      # Tracks Call ↔ NSUUID
                 ├── SystemCallBridge.kt        # CXProviderDelegate
                 ├── CallActionDispatcher.kt    # Submits CXTransactions
-                └── CallAudioRouter.kt         # AVAudioSession routing
+                └── CallAudioRouter.kt         # AVAudioSession speaker/earpiece override; iOS routes Bluetooth/wired automatically
 ```
 
 ---

--- a/shared/src/androidMain/kotlin/io/jadu/ringlr/call/CallHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/jadu/ringlr/call/CallHandler.android.kt
@@ -5,16 +5,20 @@ import android.content.pm.PackageManager
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.net.Uri
+import android.net.sip.SipAudioCall
+import android.net.sip.SipException
+import android.net.sip.SipManager
 import android.os.Build
 import android.os.Bundle
 import android.telecom.CallAudioState
 import android.telecom.Connection
 import android.telecom.TelecomManager
 import android.telephony.DisconnectCause
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import java.util.UUID
+import kotlin.coroutines.resume
 
 actual class PlatformConfiguration(
     val context: Context
@@ -64,23 +68,65 @@ actual class CallManager actual constructor(
     private val registrar = PhoneAccountRegistrar(context)
     private val telecomManager = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
     private val connections = mutableMapOf<String, Connection>()
+    private val sipCalls = mutableMapOf<String, SipAudioCall>()
     private val callStateCallbacks = mutableSetOf<CallStateCallback>()
+
+    @Suppress("DEPRECATION")
+    private var activeSipManager: SipManager? = null
+
+    @Suppress("DEPRECATION")
+    private var activeSipProfile: android.net.sip.SipProfile? = null
+
+    actual override suspend fun configureSipAccount(profile: SipProfile): CallResult<Unit> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return CallResult.Error(CallError.SipUnsupported(
+                "Android dropped built-in SIP support in API 31 (Android 12) with no official replacement. " +
+                "Ringlr handles the Telecom UI layer — bring your own SIP/VoIP stack (e.g. Linphone, PJSIP, WebRTC) " +
+                "for signaling and media, then call startOutgoingCall() once your stack has established the session."
+            ))
+        }
+        return buildSipAccount(profile)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun buildSipAccount(profile: SipProfile): CallResult<Unit> {
+        if (!SipManager.isApiSupported(context)) {
+            return CallResult.Error(CallError.ServiceError("SIP API not supported on this device", -1))
+        }
+        return try {
+            val manager = SipManager.newInstance(context)
+                ?: return CallResult.Error(CallError.ServiceError("Failed to create SipManager", -1))
+            val localProfile = android.net.sip.SipProfile.Builder(profile.username, profile.server)
+                .setPassword(profile.password)
+                .setPort(profile.port)
+                .setDisplayName(profile.displayName)
+                .build()
+            activeSipManager = manager
+            activeSipProfile = localProfile
+            CallResult.Success(Unit)
+        } catch (e: Exception) {
+            CallResult.Error(CallError.ServiceError("Failed to configure SIP account: ${e.message}", -1))
+        }
+    }
 
     actual override suspend fun startOutgoingCall(
         number: String,
         displayName: String,
         scheme: String
+    ): CallResult<Call> {
+        return if (scheme == "sip") placeSipCall(number, displayName)
+        else placePstnCall(number, displayName, scheme)
+    }
+
+    private suspend fun placePstnCall(
+        number: String,
+        displayName: String,
+        scheme: String
     ): CallResult<Call> = withContext(Dispatchers.Main) {
         try {
-            val outgoingCallExtras = Bundle().apply {
-                putString("display_name", displayName)
-            }
-
+            val extras = Bundle().apply { putString("display_name", displayName) }
             val callScheme = scheme.ifEmpty { "tel" }
-            telecomManager.placeCall(
-                Uri.fromParts(callScheme, number, null),
-                outgoingCallExtras
-            )
+            telecomManager.placeCall(Uri.fromParts(callScheme, number, null), extras)
             val call = registrar.waitForCallEstablishment(number, context)
             CallResult.Success(call)
         } catch (e: SecurityException) {
@@ -90,7 +136,59 @@ actual class CallManager actual constructor(
         }
     }
 
+    @Suppress("DEPRECATION")
+    private suspend fun placeSipCall(number: String, displayName: String): CallResult<Call> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return CallResult.Error(CallError.SipUnsupported(
+                "SIP calling is not available on Android 12+. See configureSipAccount() for details."
+            ))
+        }
+        val sipManager = activeSipManager
+            ?: return CallResult.Error(CallError.ServiceNotInitialized("Call configureSipAccount before placing a SIP call"))
+        val localProfile = activeSipProfile
+            ?: return CallResult.Error(CallError.ServiceNotInitialized("SIP account not configured"))
+
+        val peerUri = resolvePeerUri(number, localProfile.sipDomain)
+        return suspendCancellableCoroutine { continuation ->
+            val callId = UUID.randomUUID().toString()
+            val listener = object : SipAudioCall.Listener() {
+                override fun onCallEstablished(sipCall: SipAudioCall) {
+                    sipCalls[callId] = sipCall
+                    val call = Call(
+                        id = callId,
+                        number = number,
+                        displayName = displayName,
+                        state = CallState.ACTIVE,
+                        createdAt = System.currentTimeMillis(),
+                        scheme = "sip"
+                    )
+                    callStateCallbacks.forEach { it.onCallAdded(call) }
+                    continuation.resume(CallResult.Success(call))
+                }
+
+                override fun onError(sipCall: SipAudioCall?, errorCode: Int, errorMessage: String?) {
+                    continuation.resume(CallResult.Error(
+                        CallError.ServiceError(errorMessage ?: "SIP call failed", errorCode)
+                    ))
+                }
+            }
+            try {
+                sipManager.makeAudioCall(localProfile.uriString, peerUri, listener, SIP_CALL_TIMEOUT_SECONDS)
+            } catch (e: SipException) {
+                continuation.resume(CallResult.Error(
+                    CallError.ServiceError("SIP call failed: ${e.message}", -1)
+                ))
+            }
+        }
+    }
+
+    private fun resolvePeerUri(number: String, sipDomain: String): String {
+        val isSipAddress = number.contains("@")
+        return if (isSipAddress) "sip:$number" else "sip:$number@$sipDomain"
+    }
+
     actual override suspend fun endCall(callId: String): CallResult<Unit> {
+        sipCalls[callId]?.let { return endSipCall(callId, it) }
         return try {
             val activeCall = connections[callId]
                 ?: return CallResult.Error(CallError.CallNotFound(callId))
@@ -108,6 +206,17 @@ actual class CallManager actual constructor(
             CallResult.Error(CallError.PermissionDenied(e.message ?: "Permission denied"))
         } catch (e: Exception) {
             CallResult.Error(CallError.ServiceError("Failed to end call: ${e.message}", -1))
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun endSipCall(callId: String, sipCall: SipAudioCall): CallResult<Unit> {
+        return try {
+            sipCall.endCall()
+            sipCalls.remove(callId)
+            CallResult.Success(Unit)
+        } catch (e: SipException) {
+            CallResult.Error(CallError.ServiceError("Failed to end SIP call: ${e.message}", -1))
         }
     }
 
@@ -283,6 +392,10 @@ actual class CallManager actual constructor(
 
     actual override fun unregisterCallStateCallback(callback: CallStateCallback) {
         callStateCallbacks.remove(callback)
+    }
+
+    companion object {
+        private const val SIP_CALL_TIMEOUT_SECONDS = 30
     }
 }
 

--- a/shared/src/androidMain/kotlin/io/jadu/ringlr/call/PhoneAccountRegistrar.kt
+++ b/shared/src/androidMain/kotlin/io/jadu/ringlr/call/PhoneAccountRegistrar.kt
@@ -3,6 +3,7 @@ package io.jadu.ringlr.call
 import android.content.ComponentName
 import android.content.Context
 import android.os.Build
+import android.os.Bundle
 import android.telecom.PhoneAccount
 import android.telecom.PhoneAccountHandle
 import android.telecom.TelecomManager
@@ -70,6 +71,10 @@ class PhoneAccountRegistrar(private val context: Context) {
                     PhoneAccount.CAPABILITY_SUPPORTS_VIDEO_CALLING
         }
         return capabilities
+    }
+
+    internal fun addIncomingVoipCall(telecomManager: TelecomManager, extras: Bundle) {
+        telecomManager.addNewIncomingCall(customAccountHandle, extras)
     }
 
     internal fun unregisterPhoneAccount(telecomManager: TelecomManager) {

--- a/shared/src/androidMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.android.kt
+++ b/shared/src/androidMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.android.kt
@@ -1,0 +1,83 @@
+package io.jadu.ringlr.call.voip
+
+import android.content.Context
+import android.os.Bundle
+import android.telecom.TelecomManager
+import io.jadu.ringlr.call.Call
+import io.jadu.ringlr.call.CallState
+import io.jadu.ringlr.call.PhoneAccountRegistrar
+import io.jadu.ringlr.call.PlatformConfiguration
+
+/**
+ * Android implementation. Acts as a bridge between your FCM service and Ringlr.
+ *
+ * Usage in your FirebaseMessagingService:
+ * ```
+ * override fun onNewToken(token: String) {
+ *     voipPushRegistrar.handleTokenRefresh(token)
+ * }
+ *
+ * override fun onMessageReceived(message: RemoteMessage) {
+ *     if (message.data["type"] == "voip") {
+ *         voipPushRegistrar.handleVoipPush(
+ *             VoipPushPayload(
+ *                 callId       = message.data["call_id"]      ?: "",
+ *                 callerNumber = message.data["caller_number"] ?: "",
+ *                 callerName   = message.data["caller_name"]  ?: "Unknown"
+ *             )
+ *         )
+ *     }
+ * }
+ * ```
+ */
+actual class VoipPushRegistrar actual constructor(
+    private val configuration: PlatformConfiguration
+) {
+    private val context: Context get() = configuration.context
+    private val telecomManager get() = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+    private val registrar = PhoneAccountRegistrar(context)
+
+    private var listener: VoipPushListener? = null
+
+    actual fun register(listener: VoipPushListener) {
+        this.listener = listener
+    }
+
+    actual fun unregister() {
+        listener = null
+    }
+
+    actual fun handleVoipPush(payload: VoipPushPayload) {
+        val call = incomingCallFrom(payload)
+        notifyIncomingCallViaSystem(payload, call)
+        listener?.onIncomingCall(payload)
+    }
+
+    actual fun handleTokenRefresh(token: String) {
+        listener?.onTokenRefreshed(token)
+    }
+
+    private fun incomingCallFrom(payload: VoipPushPayload) = Call(
+        id = payload.callId,
+        number = payload.callerNumber,
+        displayName = payload.callerName,
+        state = CallState.RINGING,
+        createdAt = System.currentTimeMillis(),
+        scheme = payload.scheme
+    )
+
+    private fun notifyIncomingCallViaSystem(payload: VoipPushPayload, call: Call) {
+        val extras = Bundle().apply {
+            putString("call_id", call.id)
+            putString("caller_number", call.number)
+            putString("caller_name", call.displayName)
+            putString("scheme", call.scheme)
+        }
+        try {
+            registrar.addIncomingVoipCall(telecomManager, extras)
+        } catch (_: SecurityException) {
+            // MANAGE_OWN_CALLS permission missing — listener already notified above,
+            // app can still show its own in-app UI without system call screen.
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/Call.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/Call.kt
@@ -11,5 +11,6 @@ data class Call(
     val number: String,
     val displayName: String,
     val state: CallState,
-    val createdAt: Long
+    val createdAt: Long,
+    val scheme: String = "tel"
 )

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallError.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallError.kt
@@ -16,4 +16,14 @@ sealed class CallError : Exception() {
     data class NetworkError(override val message: String) : CallError()
     data class ServiceNotInitialized(override val message: String) : CallError()
     data class ServiceError(override val message: String, val code: Int) : CallError()
+
+    /**
+     * Returned when SIP/VoIP calling is requested on a platform or OS version that
+     * does not provide a built-in SIP stack.
+     *
+     * On Android 12+ (API 31+), Google removed native SIP support with no official
+     * replacement. Ringlr covers the Telecom/CallKit UI layer; the app must supply
+     * its own SIP or VoIP stack for signaling and media.
+     */
+    data class SipUnsupported(override val message: String) : CallError()
 }

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallHandler.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallHandler.kt
@@ -38,6 +38,7 @@ expect class CallManager(configuration: PlatformConfiguration) : CallManagerInte
     override suspend fun getActiveCalls(): CallResult<List<Call>>
     override suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit>
     override suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
+    override suspend fun configureSipAccount(profile: SipProfile): CallResult<Unit>
     override suspend fun checkPermissions(): CallResult<Unit>
     override fun registerCallStateCallback(callback: CallStateCallback)
     override fun unregisterCallStateCallback(callback: CallStateCallback)

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallManagerInterface.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/CallManagerInterface.kt
@@ -21,6 +21,7 @@ interface CallManagerInterface {
     suspend fun getActiveCalls(): CallResult<List<Call>>
     suspend fun setAudioRoute(route: AudioRoute): CallResult<Unit>
     suspend fun getCurrentAudioRoute(): CallResult<AudioRoute>
+    suspend fun configureSipAccount(profile: SipProfile): CallResult<Unit>
     suspend fun checkPermissions(): CallResult<Unit>
     fun registerCallStateCallback(callback: CallStateCallback)
     fun unregisterCallStateCallback(callback: CallStateCallback)

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/SipProfile.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/SipProfile.kt
@@ -1,0 +1,25 @@
+package io.jadu.ringlr.call
+
+/**
+ * Credentials and server details needed to register a SIP account.
+ *
+ * Pass to [CallManagerInterface.configureSipAccount] before placing
+ * any call with [scheme] = "sip".
+ *
+ * [sipAddress] produces the canonical "username@server" form.
+ * [sipUri]     produces the full "sip:username@server:port" URI.
+ */
+data class SipProfile(
+    val username: String,
+    val server: String,
+    val password: String,
+    val port: Int = DEFAULT_SIP_PORT,
+    val displayName: String = username
+) {
+    val sipAddress: String get() = "$username@$server"
+    val sipUri: String get() = "sip:$sipAddress:$port"
+
+    companion object {
+        const val DEFAULT_SIP_PORT = 5060
+    }
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushListener.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushListener.kt
@@ -1,0 +1,13 @@
+package io.jadu.ringlr.call.voip
+
+/**
+ * Receives VoIP push events from [VoipPushRegistrar].
+ *
+ * [onTokenRefreshed] — send this token to your push server whenever it changes.
+ * [onIncomingCall]   — an incoming VoIP call arrived; show your in-app UI or
+ *                      use [io.jadu.ringlr.call.CallManager] to manage the call.
+ */
+interface VoipPushListener {
+    fun onTokenRefreshed(token: String)
+    fun onIncomingCall(payload: VoipPushPayload)
+}

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushPayload.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushPayload.kt
@@ -1,0 +1,17 @@
+package io.jadu.ringlr.call.voip
+
+/**
+ * Parsed representation of an incoming VoIP push notification.
+ *
+ * On iOS, Ringlr extracts these fields from the PushKit payload dictionary.
+ * On Android, the app extracts them from the FCM message and passes them
+ * to [VoipPushRegistrar.handleVoipPush].
+ *
+ * Expected push payload keys: "call_id", "caller_number", "caller_name", "scheme".
+ */
+data class VoipPushPayload(
+    val callId: String,
+    val callerNumber: String,
+    val callerName: String,
+    val scheme: String = "sip"
+)

--- a/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.kt
+++ b/shared/src/commonMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.kt
@@ -1,0 +1,25 @@
+package io.jadu.ringlr.call.voip
+
+import io.jadu.ringlr.call.PlatformConfiguration
+
+/**
+ * Registers the device for VoIP push notifications and routes incoming pushes
+ * into the Ringlr call lifecycle.
+ *
+ * **iOS** — wraps PushKit ([PKPushRegistry]). Token delivery and incoming push
+ * callbacks are handled automatically once [register] is called.
+ * [handleVoipPush] and [handleTokenRefresh] are no-ops on iOS.
+ *
+ * **Android** — provides the bridge between your FCM service and Ringlr.
+ * Call [handleTokenRefresh] from [com.google.firebase.messaging.FirebaseMessagingService.onNewToken]
+ * and [handleVoipPush] from [onMessageReceived] whenever a VoIP message arrives.
+ *
+ * Always call [register] before placing or receiving any VoIP call.
+ * Call [unregister] when the calling session ends.
+ */
+expect class VoipPushRegistrar(configuration: PlatformConfiguration) {
+    fun register(listener: VoipPushListener)
+    fun unregister()
+    fun handleVoipPush(payload: VoipPushPayload)
+    fun handleTokenRefresh(token: String)
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/CallHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/CallHandler.ios.kt
@@ -8,6 +8,7 @@ import io.jadu.ringlr.call.callkit.CallAudioRouter
 import io.jadu.ringlr.call.callkit.SystemCallBridge
 import platform.CallKit.CXEndCallAction
 import platform.CallKit.CXHandle
+import platform.CallKit.CXHandleTypeGeneric
 import platform.CallKit.CXHandleTypePhoneNumber
 import platform.CallKit.CXSetHeldCallAction
 import platform.CallKit.CXSetMutedCallAction
@@ -60,6 +61,12 @@ actual class CallManager actual constructor(
     private val audioRouter get() = configuration.audioRouter
     private val observers get() = configuration.callObservers
     private val dispatcher get() = configuration.actionDispatcher
+    private var sipProfile: SipProfile? = null
+
+    actual override suspend fun configureSipAccount(profile: SipProfile): CallResult<Unit> {
+        sipProfile = profile
+        return CallResult.Success(Unit)
+    }
 
     actual override suspend fun startOutgoingCall(
         number: String,
@@ -67,10 +74,10 @@ actual class CallManager actual constructor(
         scheme: String
     ): CallResult<Call> = runCatching {
         val uuid = NSUUID()
-        val call = newCall(uuid, number, displayName)
+        val call = newCall(uuid, number, displayName, scheme)
         registry.register(call, uuid)
         observers.forEach { it.onCallAdded(call) }
-        dispatcher.dispatch(startTransaction(uuid, number, displayName))
+        dispatcher.dispatch(startTransaction(uuid, number, displayName, scheme))
         call
     }.toCallResult()
 
@@ -117,16 +124,19 @@ actual class CallManager actual constructor(
         observers.remove(callback)
     }
 
-    private fun newCall(uuid: NSUUID, number: String, displayName: String) = Call(
+    private fun newCall(uuid: NSUUID, number: String, displayName: String, scheme: String = "tel") = Call(
         id = uuid.UUIDString,
         number = number,
         displayName = displayName,
         state = CallState.DIALING,
-        createdAt = time(null)
+        createdAt = time(null),
+        scheme = scheme
     )
 
-    private fun startTransaction(uuid: NSUUID, number: String, displayName: String): CXTransaction {
-        val handle = CXHandle(type = CXHandleTypePhoneNumber, value = number)
+    private fun startTransaction(uuid: NSUUID, number: String, displayName: String, scheme: String): CXTransaction {
+        val handleType = if (scheme == "sip") CXHandleTypeGeneric else CXHandleTypePhoneNumber
+        val handleValue = if (scheme == "sip") "sip:$number" else number
+        val handle = CXHandle(type = handleType, value = handleValue)
         val action = CXStartCallAction(callUUID = uuid, handle = handle).apply {
             contactIdentifier = displayName
         }

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallAudioRouter.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/CallAudioRouter.kt
@@ -1,73 +1,55 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package io.jadu.ringlr.call.callkit
 
 import io.jadu.ringlr.call.AudioRoute
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
-import platform.AVFAudio.AVAudioSessionPortBluetoothA2DP
-import platform.AVFAudio.AVAudioSessionPortBluetoothHFP
-import platform.AVFAudio.AVAudioSessionPortBuiltInSpeaker
-import platform.AVFAudio.AVAudioSessionPortDescription
-import platform.AVFAudio.AVAudioSessionPortHeadphones
 import platform.AVFAudio.AVAudioSessionPortOverrideNone
 import platform.AVFAudio.AVAudioSessionPortOverrideSpeaker
 
 /**
  * Routes audio output for an active call using AVAudioSession.
  *
- * The session must be active (CallKit activates it automatically during a call
- * via provider(_:didActivate:)) before routing calls are meaningful.
+ * CallKit activates and deactivates the audio session automatically via
+ * [CXProviderDelegate.provider(_:didActivate:)] and
+ * [CXProviderDelegate.provider(_:didDeactivate:)]. This class only
+ * configures the session category and manages the speaker override —
+ * it does not call setActive directly.
+ *
+ * For Bluetooth and wired headset routing, iOS routes automatically to
+ * any connected device when the speaker override is removed. Apps that
+ * need fine-grained Bluetooth control should use [AVRoutePickerView].
  */
 internal class CallAudioRouter {
 
     private val session: AVAudioSession get() = AVAudioSession.sharedInstance()
+    private var activeRoute: AudioRoute = AudioRoute.EARPIECE
 
     fun activate() {
         session.setCategory(AVAudioSessionCategoryPlayAndRecord, error = null)
-        session.setActive(true, error = null)
     }
 
     fun deactivate() {
-        session.setActive(false, error = null)
+        activeRoute = AudioRoute.EARPIECE
     }
 
-    fun routeTo(destination: AudioRoute): Boolean = when (destination) {
+    fun routeTo(destination: AudioRoute): Boolean {
+        val success = applyRoute(destination)
+        if (success) activeRoute = destination
+        return success
+    }
+
+    fun currentRoute(): AudioRoute = activeRoute
+
+    private fun applyRoute(destination: AudioRoute): Boolean = when (destination) {
         AudioRoute.SPEAKER -> overrideToSpeaker()
-        AudioRoute.EARPIECE -> overrideToEarpiece()
-        AudioRoute.BLUETOOTH -> routeToBluetoothHeadset()
-        AudioRoute.WIRED_HEADSET -> routeToWiredHeadset()
-    }
-
-    fun currentRoute(): AudioRoute {
-        val outputs = session.currentRoute.outputs.filterIsInstance<AVAudioSessionPortDescription>()
-        return when {
-            outputs.any { it.portType == AVAudioSessionPortBuiltInSpeaker } -> AudioRoute.SPEAKER
-            outputs.any { it.isBluetooth() } -> AudioRoute.BLUETOOTH
-            outputs.any { it.portType == AVAudioSessionPortHeadphones } -> AudioRoute.WIRED_HEADSET
-            else -> AudioRoute.EARPIECE
-        }
+        AudioRoute.EARPIECE, AudioRoute.BLUETOOTH, AudioRoute.WIRED_HEADSET -> removeOverride()
     }
 
     private fun overrideToSpeaker(): Boolean =
         session.overrideOutputAudioPort(AVAudioSessionPortOverrideSpeaker, error = null)
 
-    private fun overrideToEarpiece(): Boolean =
+    private fun removeOverride(): Boolean =
         session.overrideOutputAudioPort(AVAudioSessionPortOverrideNone, error = null)
-
-    private fun routeToBluetoothHeadset(): Boolean {
-        val port = findInput(AVAudioSessionPortBluetoothHFP) ?: return false
-        return session.setPreferredInput(port, error = null)
-    }
-
-    private fun routeToWiredHeadset(): Boolean {
-        val port = findInput(AVAudioSessionPortHeadphones) ?: return false
-        return session.setPreferredInput(port, error = null)
-    }
-
-    private fun findInput(portType: String): AVAudioSessionPortDescription? =
-        session.availableInputs
-            ?.filterIsInstance<AVAudioSessionPortDescription>()
-            ?.firstOrNull { it.portType == portType }
-
-    private fun AVAudioSessionPortDescription.isBluetooth(): Boolean =
-        portType == AVAudioSessionPortBluetoothHFP || portType == AVAudioSessionPortBluetoothA2DP
 }

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/SystemCallBridge.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/callkit/SystemCallBridge.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package io.jadu.ringlr.call.callkit
 
 import io.jadu.ringlr.call.Call
@@ -7,6 +9,7 @@ import platform.CallKit.CXAnswerCallAction
 import platform.CallKit.CXCallUpdate
 import platform.CallKit.CXEndCallAction
 import platform.CallKit.CXHandle
+import platform.CallKit.CXHandleTypeGeneric
 import platform.CallKit.CXHandleTypePhoneNumber
 import platform.CallKit.CXProvider
 import platform.CallKit.CXProviderConfiguration
@@ -14,8 +17,8 @@ import platform.CallKit.CXProviderDelegateProtocol
 import platform.CallKit.CXSetHeldCallAction
 import platform.CallKit.CXSetMutedCallAction
 import platform.CallKit.CXStartCallAction
-import platform.Foundation.NSObject
 import platform.Foundation.NSUUID
+import platform.darwin.NSObject
 import platform.darwin.dispatch_get_main_queue
 
 /**
@@ -103,17 +106,19 @@ internal class SystemCallBridge(
 
     private fun buildCallUpdate(call: Call): CXCallUpdate =
         CXCallUpdate().apply {
-            remoteHandle = CXHandle(type = CXHandleTypePhoneNumber, value = call.number)
+            val isVoip = call.scheme == "sip"
+            val handleType = if (isVoip) CXHandleTypeGeneric else CXHandleTypePhoneNumber
+            val handleValue = if (isVoip) "sip:${call.number}" else call.number
+            remoteHandle = CXHandle(type = handleType, value = handleValue)
             localizedCallerName = call.displayName
             supportsHolding = true
-            supportsDTMF = false
+            supportsDTMF = !isVoip
             supportsGrouping = false
             supportsUngrouping = false
         }
 
     private fun buildProvider(appName: String): CXProvider {
-        val config = CXProviderConfiguration().apply {
-            localizedName = appName
+        val config = CXProviderConfiguration(localizedName = appName).apply {
             supportsVideo = false
             maximumCallGroups = 1u
             maximumCallsPerCallGroup = 1u

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.ios.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/call/voip/VoipPushRegistrar.ios.kt
@@ -1,0 +1,115 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package io.jadu.ringlr.call.voip
+
+import io.jadu.ringlr.call.Call
+import io.jadu.ringlr.call.CallState
+import io.jadu.ringlr.call.PlatformConfiguration
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.get
+import kotlinx.cinterop.reinterpret
+import platform.Foundation.NSData
+import platform.Foundation.NSUUID
+import platform.PushKit.PKPushCredentials
+import platform.PushKit.PKPushPayload
+import platform.PushKit.PKPushRegistry
+import platform.PushKit.PKPushRegistryDelegateProtocol
+import platform.PushKit.PKPushTypeVoIP
+import platform.darwin.NSObject
+import platform.darwin.dispatch_get_main_queue
+import platform.posix.time
+
+/**
+ * iOS implementation. Wraps PushKit so the app receives VoIP push tokens and
+ * incoming call payloads without any extra FCM/APNs setup.
+ *
+ * PushKit wakes the app even when it is suspended, which is required for
+ * CallKit to display the incoming call screen in time.
+ *
+ * Usage:
+ * ```
+ * val registrar = VoipPushRegistrar(platformConfig)
+ * registrar.register(object : VoipPushListener {
+ *     override fun onTokenRefreshed(token: String) { sendToServer(token) }
+ *     override fun onIncomingCall(payload: VoipPushPayload) { /* optional extra handling */ }
+ * })
+ * ```
+ *
+ * [handleVoipPush] and [handleTokenRefresh] are no-ops — PushKit delivers
+ * events directly to this delegate.
+ */
+actual class VoipPushRegistrar actual constructor(
+    private val configuration: PlatformConfiguration
+) : NSObject(), PKPushRegistryDelegateProtocol {
+
+    private var pushRegistry: PKPushRegistry? = null
+    private var listener: VoipPushListener? = null
+
+    actual fun register(listener: VoipPushListener) {
+        this.listener = listener
+        val registry = PKPushRegistry(queue = dispatch_get_main_queue())
+        registry.delegate = this
+        registry.desiredPushTypes = setOf(PKPushTypeVoIP)
+        pushRegistry = registry
+    }
+
+    actual fun unregister() {
+        pushRegistry?.delegate = null
+        pushRegistry = null
+        listener = null
+    }
+
+    actual fun handleVoipPush(payload: VoipPushPayload) = Unit
+
+    actual fun handleTokenRefresh(token: String) = Unit
+
+    override fun pushRegistry(
+        registry: PKPushRegistry,
+        didUpdatePushCredentials: PKPushCredentials,
+        forType: String?
+    ) {
+        val token = hexToken(didUpdatePushCredentials.token)
+        listener?.onTokenRefreshed(token)
+    }
+
+    override fun pushRegistry(
+        registry: PKPushRegistry,
+        didReceiveIncomingPushWithPayload: PKPushPayload,
+        forType: String?,
+        withCompletionHandler: () -> Unit
+    ) {
+        val dict = didReceiveIncomingPushWithPayload.dictionaryPayload
+        val payload = VoipPushPayload(
+            callId = dict?.get("call_id") as? String ?: NSUUID().UUIDString,
+            callerNumber = dict?.get("caller_number") as? String ?: "",
+            callerName = dict?.get("caller_name") as? String ?: "Unknown",
+            scheme = dict?.get("scheme") as? String ?: "sip"
+        )
+        reportToCallKit(payload)
+        listener?.onIncomingCall(payload)
+        withCompletionHandler()
+    }
+
+    private fun reportToCallKit(payload: VoipPushPayload) {
+        val uuid = NSUUID()
+        val call = Call(
+            id = uuid.UUIDString,
+            number = payload.callerNumber,
+            displayName = payload.callerName,
+            state = CallState.RINGING,
+            createdAt = time(null),
+            scheme = payload.scheme
+        )
+        configuration.systemBridge.reportIncomingCall(uuid, call)
+    }
+
+    private fun hexToken(tokenData: NSData): String {
+        val bytes = tokenData.bytes?.reinterpret<ByteVar>()
+        val length = tokenData.length.toInt()
+        return buildString {
+            for (i in 0 until length) {
+                append(bytes!![i].toInt().and(0xff).toString(16).padStart(2, '0'))
+            }
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermissionDelegate.kt
+++ b/shared/src/iosMain/kotlin/io/jadu/ringlr/permission/delegate/BluetoothPermissionDelegate.kt
@@ -1,10 +1,11 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package io.jadu.ringlr.permission.delegate
 
 import io.jadu.ringlr.permission.DeniedAlwaysException
 import io.jadu.ringlr.permission.DeniedException
 import io.jadu.ringlr.permission.PermissionDelegate
 import io.jadu.ringlr.permission.PermissionState
-import io.jadu.ringlr.permission.delegate.BluetoothPermission
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
@@ -13,9 +14,8 @@ import platform.CoreBluetooth.CBManagerAuthorizationAllowedAlways
 import platform.CoreBluetooth.CBManagerAuthorizationDenied
 import platform.CoreBluetooth.CBManagerAuthorizationNotDetermined
 import platform.CoreBluetooth.CBManagerAuthorizationRestricted
-import platform.Foundation.NSObject
+import platform.darwin.NSObject
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Requests and checks Bluetooth access via CBCentralManager (iOS 13+).


### PR DESCRIPTION
  VoIP / SIP Support

  - Added SipProfile data class (server, username, password, port)
  - Added configureSipAccount(profile) to CallManagerInterface
  - Android: routes SIP calls through SipManager (API ≤ 30); returns CallError.SipUnsupported on API 31+
  - iOS: uses CXHandleTypeGeneric for SIP calls instead of phone number handle
  - Added CallError.SipUnsupported — typed error for Android 12+ SIP limitation
  - Call data class gains scheme field ("tel" / "sip")

  ---
  VoIP Push Notifications

  - Added VoipPushPayload, VoipPushListener, VoipPushRegistrar
  - iOS: wraps PushKit — auto-delivers token and reports incoming call to CallKit
  - Android: bridge for FCM — app calls handleVoipPush() / handleTokenRefresh(), Ringlr registers with Telecom
